### PR TITLE
docs: add note on `micro8s` availability

### DIFF
--- a/framework/hybrid/helm/installguide.md
+++ b/framework/hybrid/helm/installguide.md
@@ -122,15 +122,17 @@ follow the installer
  - press install
  - press Finnish
   
-next run:
+Next run:
 ```shell
 > microk8s start
 ```
-run **microk8s status** to make sure the microk8s is running
+Run `microk8s status` to make sure the microk8s is running
 ### Install helm
 ```shell
 > microk8s enable helm3
 ```
+
+> 💡 Note that you have to reload/restart the command prompt to be able to run `mcro8s` (so that the prompt is using the most recent updated PATH environment variable). 
 
 ## Step 2: deploy HELM chart
 login to the acr to pull the helm chart


### PR DESCRIPTION
Micro8s may not be available directly in an open command prompt.
Needs to be reloaded/restarted first.