### PR TITLE
docs: remove leftover `<pre><code>`

### DIFF
--- a/framework/hybrid/helm/installguide.md
+++ b/framework/hybrid/helm/installguide.md
@@ -183,7 +183,7 @@ enable kubectl
 
 enable kubernetes dns extension
 ```shell
-> microk8s enable dns</code></pre>
+> microk8s enable dns
 ```
 
 login to azure


### PR DESCRIPTION
Remove leftover `<pre><code>` syntax in favor of Markdown code syntax.