### PR TITLE
chore: add `connectedk8s` installation note

### DIFF
--- a/framework/hybrid/helm/installguide.md
+++ b/framework/hybrid/helm/installguide.md
@@ -75,3 +75,5 @@ Connect an existing Kubernetes cluster
 | ------------------ | ---------------------------------- |
 | `{name}`           | wanted name arc cluster            |
 | `{resource-group}` | resource group for the arc cluster |
+
+> The command may ask to install the extension `connectedk8s` if it is not installed on the system.

--- a/framework/hybrid/helm/installguide.md
+++ b/framework/hybrid/helm/installguide.md
@@ -76,4 +76,4 @@ Connect an existing Kubernetes cluster
 | `{name}`           | wanted name arc cluster            |
 | `{resource-group}` | resource group for the arc cluster |
 
-> The command may ask to install the extension `connectedk8s` if it is not installed on the system.
+> The command may ask to install the extension `connectedk8s` if it is not installed on the system. A outdated version of `az` may also result in problems running this extension. Try upgrading the Azure CLI with `az upgrade` and run the command again.


### PR DESCRIPTION
Make sure that the `connectk8s` is installed, and that we use a recent version of `az`.