### PR TITLE
chore: inform on powershell alternative

### DIFF
--- a/framework/hybrid/helm/prerequisites/installguide-windows.md
+++ b/framework/hybrid/helm/prerequisites/installguide-windows.md
@@ -68,6 +68,9 @@ Lastly, make sure that Kubernetes uses the `~/.kube` folder to store its configu
 > cd .kube
 > microk8s config > config
 ```
+
+>  🚩 Use `cd ~` in a PowerShell terminal to navigate to the user profile folder. 
+
 To verify if Kubernetes is correctly installed and configured, check if there 
 is a cluster running with `kubectl cluster-info`
 


### PR DESCRIPTION
Inform PowerShell users to use `~` instead to navigate to the user profile folder.

Closes #162 