### PR TITLE
Docs/fix releasenotes link

### DIFF
--- a/dashboard/dashboard.md
+++ b/dashboard/dashboard.md
@@ -32,7 +32,7 @@ The following documentation pages are related to the backend of the dashboard an
 
 ## Release Notes
 
-The release notes for the dashboard can be found [here](../releases).
+The release notes for the dashboard can be found [here](https://github.com/invictus-integration/docs-ifa/releases).
 
 ## Frequently Asked Questions
 

--- a/dashboard/dashboard.md
+++ b/dashboard/dashboard.md
@@ -32,7 +32,7 @@ The following documentation pages are related to the backend of the dashboard an
 
 ## Release Notes
 
-The release notes for the dashboard can be found [here](support/releasenotes.md).
+The release notes for the dashboard can be found [here](../releases).
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
The link to the release notes on the docs page was broken (404) as the releasenotes.md file was removed since using Github releases. I've added a direct link to the repo's releases page.