### PR TITLE
docs: focussed xsd validator docs

### DIFF
--- a/framework/components/xsd-validator.md
+++ b/framework/components/xsd-validator.md
@@ -1,50 +1,43 @@
-# XSD - Validator
+# XSD Validator
 
-## Introduction
+## Motivation
 
-This documentation will give you an overview of the XSD Validator component and will help you use it.
+When processing XML files in Logic App workflows, XSD validation is a necessary pre-processing step to catch errors beforehand. [Microsoft currently only supports XSD validation within Logic App workflows on top of **Azure Integration Accounts**](https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-enterprise-integration-schemas?tabs=consumption). This kind of resource is rather expensive and therefore not always available within the cost boundaries of client projects.
 
-### Overview
+The Invictus Framework provides a **XSD Validator** component that allows you to validate XML files within you Logic App workflow by storing the XSD schemas in an Azure storage account. Circumventing the need of an expensive **Azure Integration Account**.
 
-The scope of the XSD validator is to validate a supplied XML (in Base64 format) against an XSD. XSDs with includes are supported. All XSDs are to be stored in the Azure Storage Container **xsdvalidatorstore**.
+## Usage
 
-## Input
+The **XSD Validator** is available as a HTTP endpoint in your Logic App workflow. XML input files should be supplied in a `BASE64` format, XSD schema files should be stored in the Azure Blob storage container.
 
-As an input, the XML in Base64 format (**content**) and the name of the XSD file (**xsdName**) need to be supplied as follows:
+### Prerequisites
 
-`{
-	"content": "PD94bWwgdmVyc2lvbiA9ICIxLjAiPz4KPGNsYXNzPiAgCiAg...",   
-    "xsdName": "valid-sample.xsd"
-}`
+* XSD schema file(s), stored in the Azure Blob container `xsdvalidatorstore` (available upon installation).
 
-When setting up your Logic App, the HttpRequest is to be setup as follows:
+### Input
 
-![Http Request](../../images/xsd-validator-httprequest.png)
+The request to the HTTP endpoint should contain both the `BASE64` formatted XML input file, as the name of the XSD schema file, stored in the Azure Blob storage container.
 
-The request is then followed by the execution of the function **ValidateXmlAgainstXsd** as follows:
+```json
+// POST -> /api/ValidateXmlAgainstXsd
+{
+    "content": "<base64-encoded-input-xml>",
+    "xsdName": "<name-of-stored-schema-file>.xsd"
+}
+```
 
-![ValidateXmlAgainstXsd Function](../../images/xsd-validator-validatexmlagainstxsdfunction.png)
+### Output
 
-## Output
+A successful HTTP response includes whether the schema validation was successful and any additional validation failures that were encountered.
 
-After the XML is validated against the XSD, the result for a successful validation is returned with **IsValid** as true, with no **Exceptions** as follows:
-
-`{
-    "IsValid": true,
-    "Exceptions": []
-}`
-
-If the validation is unsuccessful, the output is returned with **IsValid** as false, together with a list of **Exceptions** as follows:
-
-`{
-    "IsValid": false,
-    "Exceptions": [
+```json
+// 200 OK <- /api/ValidateXmlAgainstXsd
+{
+    "isValid": false,
+    "exceptions": [
         {
-            "message": "The element 'student' has invalid child element 'lastname'. List of possible elements expected: 'firstname'."
+            "message": "ex. The element 'student' has invalid child element 'lastname'. List of possible elements expected: 'firstname'." 
         }
     ]
-}`
-
-The response to the function **ValidateXmlAgainstXsd** is to be setup as follows:
-
-![Http Response](../../images/xsd-validator-httpresponse.png)
+}
+```


### PR DESCRIPTION
* Add motivation to XSD Validator feature documentation;
* Add JSON syntax to request/response of the XSD Validator function;
* Remove project-too-specific Logic Apps workflow screenshots (as they are just using the built-in HTTP call in Logic Apps). 