### PR TITLE
docs: propose alternative role management structure

### DIFF
--- a/dashboard/role-management.md
+++ b/dashboard/role-management.md
@@ -1,34 +1,33 @@
 [home](../README.md) | [dashboard](dashboard.md) | [Role Management](role-management.md)
 
 # Role Management
+Permissions in the Invictus Dashboard are separated into two categories: user roles and folder level roles.
 
-Roles in the invictus dashboard are separated into two categories: Global roles and folder level roles.
+* **User roles**: A user or group of users can be assigned a role in the application.
 
-## Global Roles
+  * *System admin*: has all rights and access to all pages, functionality and flows.
+ 
+  * *Non admin*: has only access to certain pages, cannot perform any system-wide operations, and flow-access is granted for each folder.
 
-### System Admin
-A user with this role automatically has all rights and access to all flows and folders. Users with this role can also manage users and grant/deny access on folder level to other users. System admins may also setup group permissions, view audits and set up dashboard settings. 
+  | System functionality | Non admin   | System admin   |
+  | -------------------- | :---------: | :------------: |
+  | CRUD users           | 🔴          | 🟢            |
+  | CRUD groups          | 🔴          | 🟢            |
+  | CRUD settings        | 🔴          | 🟢            |
+  | CRUD alerts          | 🔴          | 🟢            |
+  | CRUD folder/flows    | 🟡          | 🟢            |
+  | View audits          | 🔴          | 🟢            |
+  | View flow data       | 🟢          | 🟢            |
+  | View statistics      | 🟢          | 🟢            |
 
-### Non Admin
-A user with the non-admin role will have not have access to any folder or flow by default and cannot perform any system wide operations. However, these users may then be granted folder level roles per folder.
 
-## Folder Level Roles
+* **Folder permissions**: Anything folder- or flow-related is authorized with a more fine-grained role management system for *Non admin* users/groups.
 
-### Folder Admin
-Does not have access to any folder/flow by default. This role is assigned to non-admin users at a folder level by a System Admin. This role can perform certain administrative tasks only within the folder where they are assigned to but cannot manage users on the dashboard in general. 
+  | Folder functionality     | Reader   | Operator   | Folder admin   |
+  | ------------------------ | :------: | :--------: | :------------: |
+  | CRUD folder/flows        | 🔴       | 🔴        | 🟢             |
+  | Grant folder permissions | 🔴       | 🔴        | 🟢             |
+  | Execute flows*           | 🔴       | 🟢        | 🟢             |
+  | View folder/flows        | 🟢       | 🟢        | 🟢             |
 
-### Operator
-Does not have access to any folder/flow by default.  This role is assigned to non-admin users at folder level.  Users with this role have access to perform certain tasks within the folder and its flows.
-
-### Reader
-Does not have access to any folder/flow by default. This role is assigned to non-admin users at folder level. Users with this role only have permission to view flow data but cannot perform any operations. 
-
-## Permissions per role
-
-### System Wide Functionality Permissions
-
-![user mgmt](../images/v2_role_management1.png)
-
-### Folder-Level Functionality Permissions
-
-![user mgmt](../images/v2_role_management2.png)
+> \* *Flows can be resubmitted, resumed, and ignored via the Dashboard.*


### PR DESCRIPTION
* Uses a Markdown table to show the different roles instead of a screenshot; this for better maintainability and rendering.
* Combine certain functionality into simpler wording.
* Use color scheme and orderning for easier navigation. 🔴🟡🟢
* Remove the `System admin` role from the folder-specific roles to not complicate things.