### PR TITLE
docs: use 🟡 for non-admin users that access flow data

### DIFF
--- a/dashboard/role-management.md
+++ b/dashboard/role-management.md
@@ -17,7 +17,7 @@ Permissions in the Invictus Dashboard are separated into two categories: user ro
   | CRUD alerts          | 🔴          | 🟢            |
   | CRUD folder/flows    | 🟡          | 🟢            |
   | View audits          | 🔴          | 🟢            |
-  | View flow data       | 🟢          | 🟢            |
+  | View flow data       | 🟡          | 🟢            |
   | View statistics      | 🟢          | 🟢            |
 
 


### PR DESCRIPTION
Only when `Non admin` users have permissions granted will they be able to access the flow data.