### PR TITLE
Refine sidebar structure to differentiate between Deprecated and Actve components

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,12 +1,12 @@
 <!-- markdownlint-disable -->
 
-* [Home :house_with_garden:](/)
+* [Home 🏡](/)
 * [Architecture](/architecture/architecture-diagram.md)
 * Dashboard
   * [Overview](/dashboard/dashboard.md)
   * [Installation](/dashboard/installation/dashboard-installation.md)
     * [Build Pipeline](/dashboard/installation/dashboard-buildpipeline.md)
-    * [Release Pipeline :rocket:](/dashboard/installation/dashboard-releasepipeline.md)
+    * [Release Pipeline 🚀](/dashboard/installation/dashboard-releasepipeline.md)
     * [Migration Guide](/dashboard/installation/dashboard-migration.md)
     * [VNET Support](/dashboard/installation/dashboard-vnet.md)
     * [Azure Active Directory Setup](/dashboard/azureADSetup.md)
@@ -15,7 +15,7 @@
     * [Setup](/dashboard/setup.md)
     * [Home page](/dashboard/home.md)
     * [Forgot Password](/dashboard/forgotpassword.md)
-    * [Folders & Flows](/dashboard/foldersflows.md)
+    * [Folders &amp; Flows](/dashboard/foldersflows.md)
     * [Flow Auditing](/dashboard/flowauditing.md)
     * [Alerting](/dashboard/alerting.md)
     * [Search](/dashboard/search.md)
@@ -23,35 +23,35 @@
     * [Execution Tree](/dashboard/executiontree.md)
     * [Settings](/dashboard/settings.md)
   * Security and permissions
-    * [User Management](/dashboard/usermanagement.md) 
-    * [Role Management](/dashboard/role-management.md) 
-    * [Manage folder permissions](/dashboard/foldermanagement.md) 
+    * [User Management](/dashboard/usermanagement.md)
+    * [Role Management](/dashboard/role-management.md)
+    * [Manage folder permissions](/dashboard/foldermanagement.md)
   * Backend Documentation
     * [Flow Handler](/dashboard/flowhandler.md)
     * [Import Job](/dashboard/importjob.md)
   * Support
-    * [Release Notes :fire:](https://github.com/invictus-integration/docs-ifa/releases)
-    * [FAQ :question:](/dashboard/support/faq.md)
+    * [Release Notes 🔥](https://github.com/invictus-integration/docs-ifa/releases)
+    * [FAQ ❓](/dashboard/support/faq.md)
 * Framework
   * [Overview](/framework/framework.md)
   * [Installation](/framework/installation/framework-installation.md)
     * [Build Pipeline](/framework/installation/framework-buildpipeline.md)
-    * [Release Pipeline :rocket:](/framework/installation/framework-releasepipeline.md)
+    * [Release Pipeline 🚀](/framework/installation/framework-releasepipeline.md)
     * [Migration Guide](/framework/installation/framework-migration.md)
   * Components
-    * v1
-      * [Publish and Subscribe](/framework/components/pubsub.md)
+    * Deprecated components
+      * [PubSub V1](/framework/components/pubsub.md)
       * [Matrix](/framework/components/matrix.md)
         * [Basic Promotion](/framework/components/matrix-basic.md)
         * [Matrix Promotion](/framework/components/matrix-promote.md)
-    * [Transco](/framework/components/transco.md)
-      * [Transco Extraction](/framework/components/transco-extraction.md)
-      * [Transco Custom Assemblies](/framework/components/transco-assemblies.md)
-    * v2
-      * [PubSubV2](/framework/components/pubsubV2.md)
-      * [TranscoV2](/framework/components/transcoV2.md)
-        * [TranscoV2 Matrix](/framework/components/transcoV2-Matrix.md)
-        * [TranscoV2 Example](/framework/components/transcoV2-Example.md)
+      * [Transco V1](/framework/components/transco.md)
+        * [Transco Extraction](/framework/components/transco-extraction.md)
+        * [Transco Custom Assemblies](/framework/components/transco-assemblies.md)
+    * Active components
+      * [Publish and Subscribe ](/framework/components/pubsubV2.md)
+      * [Transco](/framework/components/transcoV2.md)
+        * [Transco Matrix](/framework/components/transcoV2-Matrix.md)
+        * [Transco Example](/framework/components/transcoV2-Example.md)
       * [Time sequencer](/framework/components/timesequencer.md)
       * [XSD validator](/framework/components/xsd-validator.md)
       * [Regex translator](/framework/components/regextranslation.md)
@@ -59,7 +59,7 @@
       * [Sequence controller](/framework/components/sequencecontroller.md)
       * [Exception Handler](/framework/components/exceptionHandler.md)
   * Related Documentation
-    * [LogicApps diagnostics](/framework/logicappsdiagnostics.md) 
-    * [DataFactory diagnostics](/framework/datafactorydiagnostics.md) 
+    * [LogicApps diagnostics](/framework/logicappsdiagnostics.md)
+    * [DataFactory diagnostics](/framework/datafactorydiagnostics.md)
   * Support
-    * [Release Notes :fire:](https://github.com/invictus-integration/docs-ifa/releases)
+    * [Release Notes 🔥](https://github.com/invictus-integration/docs-ifa/releases)


### PR DESCRIPTION
Refine sidebar structure to differentiate between Deprecated and Active framework components

Also removed the 'V2' naming from the active components, as they are now considered the standard.