### PR TITLE
chore: Update CODEOWNERS with Sam-only rights

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*       @invictus-integration/invictus-maintainers
+*       @GoutsmitSam


### PR DESCRIPTION
Only @GoutsmitSam is Code Owner of Invictus and should have end-decision-rights on anything directly made public.