### PR TITLE
fix(transco): transco v2 config default value description

### DIFF
--- a/framework/components/transcoV2.md
+++ b/framework/components/transcoV2.md
@@ -65,7 +65,7 @@ A JSON Transco config file is required to specify details about the instruction 
     				"databaseKeyVaultName": [Name of DB connection string secret in Key Vault],
     				"commandValue": [SQL query to be executed],
     				"isMandatory": [If true, will throw error when result is null],
-    				"defaultValue": [Default value of result],
+    				"defaultValue": [Fallback value of result when the command does not return any rows],
     				"parameters": [
     					{
     						"paramName": [Name of param in query],
@@ -143,7 +143,7 @@ or
     		"databaseKeyVaultName": [Name of DB connection string secret in Key Vault],
     		"commandValue": [SQL query to be executed],
     		"isMandatory": [If true, will throw error when result is null],
-    		"defaultValue": [Default value of result],
+    		"defaultValue": [Fallback value of result when the command does not return any rows],
     		"parameters": [
     					{
     						"paramName": [Name of param in query],


### PR DESCRIPTION
There is a subtle difference in the 'default value': is it used when the column does not return a value, when the command does not reflect to any rows...

This PR makes this subtle difference more clear by explaining where this default value is being used.