### PR TITLE
docs(la.diagnostic): use microsoft docs + bicep avm

### DIFF
--- a/framework/logicappsdiagnostics.md
+++ b/framework/logicappsdiagnostics.md
@@ -1,126 +1,37 @@
-[home](../README.md) | [framework](framework.md)
+# Enable LogicApps Diagnostics
+For the Invictus Dashboard to know if messages went through your Logic App workflow correctly or not, diagnostic settings need to be configured on all Logic Apps that you want to include. These settings should stream their diagnostic traces to the Invictus EventHubs resource:
 
-# LogicApps Diagnostics
+* `EventHubsNamespace`: `invictus-{env}-we-sft-evnm`
+* `EventHubsName`: `invictus-{env}-we-sft-evhb-v2`
 
-To enable diagnostics and automatically stream all WorkFlowRuntime events from your Logic Apps to event hub use the template below.
+> ⚠️ Make sure that the `WorkflowRuntime` is **✅ checked**, but the `AllMetrics` is **❌ unchecked**. Otherwise you will send far too much events to the EventHubs.
 
-The Logic App is just to demonstrate where the DiagnosticSetting resource needs to be placed. It is important to also target the EventHubNamespace and EventHubName created by the Invictus Resources ARM Template, since the Import Job is set to listen on the mentioned Namespace and Hub.
+![diagnostics](../images/ladiagnostics.png)
 
-After the below code is executed you should be able to see the setup as displayed in the image in your Logic App Diagnostic Settings section.
+> 🔗 See [Microsoft's documentation](https://learn.microsoft.com/en-us/azure/logic-apps/monitor-workflows-collect-diagnostic-data?tabs=consumption) on how this can be configured manually.
 
-> ![diagnostics](../images/ladiagnostics.png)
+Alternatively, you can update your Bicep template to include them, using [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/logic/workflow#parameter-diagnosticsettings):
 
-## Sample ARM Template
-
-```json
+```bicep
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "logicAppName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the Logic App that will be created."
-      }
-    },
-    "testUri": {
-      "type": "string",
-      "defaultValue": "http://azure.microsoft.com/status/feed/"
-    },
-    "settingName": {
-      "type": "string",
-      "defaultValue": "MonitorWorkFlowRuntime"
-    },
-    "eventHubAuthorizationRuleId": {
-      "type": "string",
-      "defaultValue": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', 'invictus-stg-we-sft-evhb', 'RootManageSharedAccessKey')]"
-    },
-    "eventHubNamespace": {
-      "type": "string",
-      "defaultValue": "The EventHub Namespace you wish to target"
-    },
-    "eventHubName": {
-      "type": "string",
-      "defaultValue": "The EventHub name you wish to target(not the namespace)"
-    }
-  },
-  "variables": {},
-  "resources": [
-    {
-      "type": "Microsoft.Logic/workflows",
-      "name": "[parameters('logicAppName')]",
-      "apiVersion": "2016-06-01",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "definition": {
-          "$schema": "https://schema.management.azure.com/schemas/2016-06-01/Microsoft.Logic.json",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "testURI": {
-              "type": "string",
-              "defaultValue": "[parameters('testUri')]"
-            }
-          },
-          "triggers": {
-            "recurrence": {
-              "type": "recurrence",
-              "recurrence": {
-                "frequency": "Hour",
-                "interval": 1
-              }
-            }
-          },
-          "actions": {
-            "http": {
-              "type": "Http",
-              "inputs": {
-                "method": "GET",
-                "uri": "@parameters('testUri')"
-              },
-              "runAfter": {}
-            }
-          },
-          "outputs": {}
-        },
-        "parameters": {}
-      },
-      "resources": [
+  ...
+  diagnosticSettings: [
       {
-          "type": "providers/diagnosticSettings",
-          "name": "[concat('Microsoft.Insights/', parameters('settingName'))]",
-          "dependsOn": [
-            "[resourceId('Microsoft.Logic/workflows', parameters('logicAppName'))]"
-          ],
-          "apiVersion": "2017-05-01-preview",
-        "properties": {
-          "name": "[parameters('settingName')]",
-          "eventHubAuthorizationRuleId": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventHubNamespace'), 'RootManageSharedAccessKey')]",
-          "eventHubName": "[parameters('eventHubName')]",
-          "logs": [
-            {
-              "category": "WorkflowRuntime",
-              "enabled": true,
-              "retentionPolicy": {
-                "days": 0,
-                "enabled": false
-              }
-            }
-          ]
-        }
-        }
-      ],
-      "dependsOn": []
-    }
-  ]
-}
-```
-
-Note if the templates are stored in a different resources use the below code to reference the EventHubNamespace in another resource:
-
-```json
-{
-    ...
-    "eventHubAuthorizationRuleId": "[resourceId(parameters('targetResourceGroup'),'Microsoft.EventHub/namespaces/authorizationRules', parameters('eventHubNamespace'), 'RootManageSharedAccessKey')]"
-    ...
+        name: settingName
+        eventHubName: eventHubName
+        eventHubAuthorizationRuleResourceId: resourceId(
+          resourceGroupName,
+          'Microsoft.EventHub/namespaces/authorizationRules',
+          eventHubNamespace,
+          'RootManageSharedAccessKey'
+        )
+        logCategoriesAndGroups: [
+          {
+            category: 'WorkflowRuntime'
+            enabled: true
+          }
+        ]
+      }
+    ]
 }
 ```


### PR DESCRIPTION
Simplifies and re-focus the Logic Apps enable diagnostic settings page on what's important:
* `AllMetrics` should not be enabled;
* `WorkflowRuntime` should be enabled;
* `EventHubsName(space)` should point to Invictus EventHubs resource.

Adding a full sample, with already a Logic App embedded both forces us to regularly maintain the deployment. The sample has been reduced to using AVM (recommended by the Practice instead of ARM) and only showing the necessary changes to new/existing deployment templates.