### PR TITLE
docs(flow): move diagnostic settings pages to import flow sidebar item

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -18,6 +18,9 @@
       * [Flow execution tree](/dashboard/executiontree.md)
       * [Audit flows](/dashboard/flowauditing.md)
       * [Flow permissions](/dashboard/foldermanagement.md)
+      * Import flows
+        * [LogicApps diagnostics](/framework/logicappsdiagnostics.md)
+        * [DataFactory diagnostics](/framework/datafactorydiagnostics.md)
     * Security
       * [Forgot Password](/dashboard/forgotpassword.md)
       * [Users](/dashboard/usermanagement.md)
@@ -42,9 +45,6 @@
     * [XML/Json convertor](/framework/components/xmljsonconverter.md)
     * [Sequence controller](/framework/components/sequencecontroller.md)
     * [Exception Handler](/framework/components/exceptionHandler.md)
-* Related Documentation
-  * [LogicApps diagnostics](/framework/logicappsdiagnostics.md)
-  * [DataFactory diagnostics](/framework/datafactorydiagnostics.md)
 * Support
   * [Release Notes 🔥](https://github.com/invictus-integration/docs-ifa/releases)
   * [VNET Support](/dashboard/installation/dashboard-vnet.md)


### PR DESCRIPTION
The ways to 'import flows' into the dashboard was 'hidden' under **Related documentation**. While this is a fundamental part of setting up the dashboard correctly.
This PR moves this to a sub-section of the **Flows** in the sidebar. Making it more clear that it all talks about the same thing.