### PR TITLE
docs(la.diagnostic-settings): split between consumption/standard logic apps evhb

### DIFF
--- a/framework/logicappsdiagnostics.md
+++ b/framework/logicappsdiagnostics.md
@@ -2,7 +2,9 @@
 For the Invictus Dashboard to know if messages went through your Logic App workflow correctly or not, diagnostic settings need to be configured on all Logic Apps that you want to include. These settings should stream their diagnostic traces to the Invictus EventHubs resource:
 
 * `EventHubsNamespace`: `invictus-{env}-we-sft-evnm`
-* `EventHubsName`: `invictus-{env}-we-sft-evhb-v2`
+* `EventHubsName`:
+  * `invictus-{env}-we-sft-evhb` (Logic Apps Consumption) 
+  * `invictus-{env}-we-sft-evhb-v2` (Logic Apps Standard)
 
 > ⚠️ Make sure that the `WorkflowRuntime` is **✅ checked**, but the `AllMetrics` is **❌ unchecked**. Otherwise you will send far too much events to the EventHubs.
 


### PR DESCRIPTION
Make sure that we show where each diagnostic trace should be send to which EventHubs resource for types of Logic Apps.