### PR TITLE
chore(flow): remove re-import from flow actions

### DIFF
--- a/architecture/architecture-diagram.md
+++ b/architecture/architecture-diagram.md
@@ -10,7 +10,7 @@
 
 - **Frontend:** Consists of the web application which is used to monitor all flows in the system.
 - **Dashboard Gateway:** Serves as the backend for the web application, handles all interactions with the database and other dependencies.
-- **Flow Handler:** Handles interactions with the Azure management api for the flow actions (Ignore, Resubmit, Resume, Reimport), flow alerts and message content view features.
+- **Flow Handler:** Handles interactions with the Azure management api for the flow actions (Ignore, Resubmit, Resume), flow alerts and message content view features.
 - **Import Functions:** Consist of ImportJob, CacheImportJob and StoreImportJob. The ImportJob functions are used to listen on EventHub for all LogicApp executions, all data is then merged and finally pushed to the Database.
 - **CosmosDB:** Stores all the data necessary for the frontend to function such as users, folders, settings. Flow data and workflowevents are also saved to the CosmosDB by the *DatabaseManager* function.
 - **Event Hub:** Logic App diagnostic messages are sent to event hub where they are picked up and processed by the Invictus import functions.

--- a/dashboard/messagehandling.md
+++ b/dashboard/messagehandling.md
@@ -1,6 +1,6 @@
 # Dashboard Message Handling
 
-Users have to option to resubmit, resume, reimport and ignore one or many messages.
+Users have to option to resubmit, resume and ignore one or many messages.
 
 This can be done in one of two ways: 
 
@@ -15,7 +15,7 @@ Select the desired messages via their respective checkbox. At the bottom of the 
 
 ![handling buttons](../images/v2_handling2.png)
 
-## Custom Resume and Resubmit and Reimport
+## Custom Resume and Resubmit
 
 It's possible to use a custom resubmit and resume, see [this page](custom-resumeresubmit.md) for more information.
 
@@ -34,20 +34,6 @@ If we had to take the above image as an example. If Resubmit is executed for thi
 The Resume function executes an "Azure Resubmit" for each failed function in the chain. Resume only works on messages with the status Failed. Also, the Resume does not start from the first logic app within its flow, as with the Resubmit, but instead executes only the failed logic apps.
 
 **The only exception is that if a Parent Logic App of a failed Logic App has also failed, then only the Parent is executed**.
-
-## Reimport
-
-The Resume function executes an "Azure Resubmit" for each failed function in the chain. **The only exception is that if a Parent Logic App of a failed Logic App has also failed, then only the Parent is executed**. Reimport will retrigger the merging process from Storage to CosmosDB. This should only be used in cases where some messages are stuck in an incomplete state.
-
-![resume](../images/dashboard/FlowHandler/fh-resubmit1.jpg)
-
-To give an example, Resume was triggered on the above flow, notice in the image below that only B and C have been retried. Also, since C is the product of B, the Azure Resubmit was only triggered on B.
-
-![resume](../images/dashboard/FlowHandler/fh-resume1.jpg)
-
-The below image is a more in-depth example of how the Resume functionality behaves with more than one scenario. Assume that each box is a LogicApp.
-
-![resume detail](../images/fh-detail.png)
 
 ## Ignore
 


### PR DESCRIPTION
Since we stopped supporting 're-importing' of flows, we should remove it from the feature documentation. This PR removes it from the architecture diagram as well as the flow actions page.