### PR TITLE
docs(flow.df): streamline import flows sidebar item for data-factory

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -16,7 +16,7 @@
       * [Flow permissions](/dashboard/foldermanagement.md)
       * [Import flow traces](/dashboard/import-flows.md)
         * [Import via LogicApps](/dashboard/import-flows-via-la.md)
-        * [DataFactory diagnostics](/framework/datafactorydiagnostics.md)
+        * [Import via DataFactory](/framework/datafactorydiagnostics.md)
         * [Import prog. via HTTP](/dashboard/import-flow-prog-via-http.md)
         * [Import prog. via EventHubs](/dashboard/import-flow-prog-via-eh.md)
     * Security


### PR DESCRIPTION
Streamlines the 'import flow traces' for DataFactory with the other items in the sidebar, for a more user-friendly/visual-attractive sidebar.