### PR TITLE
fix(md): use empty a href io incomplete markdown link

### DIFF
--- a/dashboard/azureADSetup.md
+++ b/dashboard/azureADSetup.md
@@ -14,11 +14,11 @@ To use your Azure Active Directory groups as a way of authentication and flow au
      * Assign <u>Owners</u> ([more info](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-app-owners?pivots=portal))
      * Grant <u>Admin consent</u> ([more info](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent?pivots=portal))
 
-1. [**Let app expose an API with scoped permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#add-a-scope)
+2. [**Let app expose an API with scoped permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#add-a-scope)
    * Use default <u>Application ID URI</u> (copy value for later use).
    * Add scope with <u>Admin and users</u> consent.
 
-2. [**Add API permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis)
+3. [**Add API permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis)
    * <u>Microsoft.Graph/</u>
      * <u>Directory.Read.All</u> **Delegated** (looking up directory objects)
      * <u>User.Read</u> **Delegated** (looking up users)
@@ -27,7 +27,7 @@ To use your Azure Active Directory groups as a way of authentication and flow au
      * <u>Mail.Send</u> **Application** (sending 'forgot password' mails)
    * <u>My API's</u> **Delegated** (the scoped API permission you've created in the previous step)
 
-3. **Pass app registration values to Invictus deployment**
+4. **Pass app registration values to Invictus deployment**
    * `azureActiveDirectoryClientId` (**App registration > overview**)
    * `azureActiveDirectoryTenantId` (**App registration > overview**)
    * `azureActiveDirectoryClientSecret` (paste from previous generation)

--- a/dashboard/azureADSetup.md
+++ b/dashboard/azureADSetup.md
@@ -4,8 +4,8 @@ To use your Azure Active Directory groups as a way of authentication and flow au
 1. [**Register an application Invictus redirects**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app?tabs=certificate%2Cexpose-a-web-api)
    * Choose the <u>multi-tenant</u> account type option to let Invictus be able to use the app registration.
    * Add <u>Redirect URI`s</u> to **your** Invictus pages, i.e.:
-     * [https://your-invictusdashboard.azurewebsites.net/login]()
-     * [https://your-invictusdashboard.azurewebsites.net/api/auth/callback/azure-ad]()
+     * <a href="">https://your-invictusdashboard.azurewebsites.net/login</a> 
+     * <a href="">https://your-invictusdashboard.azurewebsites.net/api/auth/callback/azure-ad</a>
      * 👉 Make sure to check the **☑️ Access tokens** checkbox to issue tokens ([more info](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-implicit-grant-flow?WT.mc_id=Portal-Microsoft_AAD_RegisteredApps))
    * Add new <u>client secret</u> (copy value for later use)
    * Linked Enterprise application:

--- a/dashboard/azureADSetup.md
+++ b/dashboard/azureADSetup.md
@@ -4,21 +4,21 @@ To use your Azure Active Directory groups as a way of authentication and flow au
 1. [**Register an application Invictus redirects**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app?tabs=certificate%2Cexpose-a-web-api)
    * Choose the <u>multi-tenant</u> account type option to let Invictus be able to use the app registration.
    * Add <u>Redirect URI`s</u> to **your** Invictus pages, i.e.:
-      <!-- md-dead-link-check: off -->
-     * <a href="">https://your-invictusdashboard.azurewebsites.net/login</a> 
-     * <a href="">https://your-invictusdashboard.azurewebsites.net/api/auth/callback/azure-ad</a>
-      <!-- md-dead-link-check: on -->
+<!-- md-dead-link-check: off -->
+     * <a href="/">https://your-invictusdashboard.azurewebsites.net/login</a> 
+     * <a href="/">https://your-invictusdashboard.azurewebsites.net/api/auth/callback/azure-ad</a>
+<!-- md-dead-link-check: on -->
      * 👉 Make sure to check the **☑️ Access tokens** checkbox to issue tokens ([more info](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-implicit-grant-flow?WT.mc_id=Portal-Microsoft_AAD_RegisteredApps))
    * Add new <u>client secret</u> (copy value for later use)
    * Linked Enterprise application:
      * Assign <u>Owners</u> ([more info](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-app-owners?pivots=portal))
      * Grant <u>Admin consent</u> ([more info](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent?pivots=portal))
 
-2. [**Let app expose an API with scoped permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#add-a-scope)
+1. [**Let app expose an API with scoped permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#add-a-scope)
    * Use default <u>Application ID URI</u> (copy value for later use).
    * Add scope with <u>Admin and users</u> consent.
 
-3. [**Add API permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis)
+2. [**Add API permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis)
    * <u>Microsoft.Graph/</u>
      * <u>Directory.Read.All</u> **Delegated** (looking up directory objects)
      * <u>User.Read</u> **Delegated** (looking up users)
@@ -27,7 +27,7 @@ To use your Azure Active Directory groups as a way of authentication and flow au
      * <u>Mail.Send</u> **Application** (sending 'forgot password' mails)
    * <u>My API's</u> **Delegated** (the scoped API permission you've created in the previous step)
 
-4. **Pass app registration values to Invictus deployment**
+3. **Pass app registration values to Invictus deployment**
    * `azureActiveDirectoryClientId` (**App registration > overview**)
    * `azureActiveDirectoryTenantId` (**App registration > overview**)
    * `azureActiveDirectoryClientSecret` (paste from previous generation)

--- a/dashboard/azureADSetup.md
+++ b/dashboard/azureADSetup.md
@@ -4,19 +4,21 @@ To use your Azure Active Directory groups as a way of authentication and flow au
 1. [**Register an application Invictus redirects**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app?tabs=certificate%2Cexpose-a-web-api)
    * Choose the <u>multi-tenant</u> account type option to let Invictus be able to use the app registration.
    * Add <u>Redirect URI`s</u> to **your** Invictus pages, i.e.:
+      <!-- md-dead-link-check: off -->
      * <a href="">https://your-invictusdashboard.azurewebsites.net/login</a> 
      * <a href="">https://your-invictusdashboard.azurewebsites.net/api/auth/callback/azure-ad</a>
+      <!-- md-dead-link-check: on -->
      * 👉 Make sure to check the **☑️ Access tokens** checkbox to issue tokens ([more info](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-implicit-grant-flow?WT.mc_id=Portal-Microsoft_AAD_RegisteredApps))
    * Add new <u>client secret</u> (copy value for later use)
    * Linked Enterprise application:
      * Assign <u>Owners</u> ([more info](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-app-owners?pivots=portal))
      * Grant <u>Admin consent</u> ([more info](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent?pivots=portal))
 
-2. [**Let app expose an API with scoped permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#add-a-scope)
+1. [**Let app expose an API with scoped permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#add-a-scope)
    * Use default <u>Application ID URI</u> (copy value for later use).
    * Add scope with <u>Admin and users</u> consent.
 
-3. [**Add API permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis)
+2. [**Add API permissions**](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis)
    * <u>Microsoft.Graph/</u>
      * <u>Directory.Read.All</u> **Delegated** (looking up directory objects)
      * <u>User.Read</u> **Delegated** (looking up users)
@@ -25,7 +27,7 @@ To use your Azure Active Directory groups as a way of authentication and flow au
      * <u>Mail.Send</u> **Application** (sending 'forgot password' mails)
    * <u>My API's</u> **Delegated** (the scoped API permission you've created in the previous step)
 
-4. **Pass app registration values to Invictus deployment**
+3. **Pass app registration values to Invictus deployment**
    * `azureActiveDirectoryClientId` (**App registration > overview**)
    * `azureActiveDirectoryTenantId` (**App registration > overview**)
    * `azureActiveDirectoryClientSecret` (paste from previous generation)

--- a/framework/components/deprecated/pubsub.md
+++ b/framework/components/deprecated/pubsub.md
@@ -64,7 +64,7 @@ The MessageId property in the Publish will be used for duplicate detection. This
    ![swagger](../../../images/pubsub-swagger.png)
 
 <!-- md-dead-link-check: off -->
-9. Enter the swagger url (eg: for PubSub <a href="">https://invictus-dev-we-sft-pubsubapp.azurewebsites.net/swagger/docs/v1</a>).
+9. Enter the swagger url (eg: for PubSub <a href="/">https://invictus-dev-we-sft-pubsubapp.azurewebsites.net/swagger/docs/v1</a>).
 <!-- md-dead-link-check: on -->
 
    ![swagger connector](../../../images/pubsub-swaggerconnector.png)

--- a/framework/components/deprecated/pubsub.md
+++ b/framework/components/deprecated/pubsub.md
@@ -63,7 +63,9 @@ The MessageId property in the Publish will be used for duplicate detection. This
 
    ![swagger](../../../images/pubsub-swagger.png)
 
+<!-- md-dead-link-check: off -->
 9. Enter the swagger url (eg: for PubSub <a href="">https://invictus-dev-we-sft-pubsubapp.azurewebsites.net/swagger/docs/v1</a>).
+<!-- md-dead-link-check: on -->
 
    ![swagger connector](../../../images/pubsub-swaggerconnector.png)
 

--- a/framework/components/deprecated/pubsub.md
+++ b/framework/components/deprecated/pubsub.md
@@ -63,7 +63,7 @@ The MessageId property in the Publish will be used for duplicate detection. This
 
    ![swagger](../../../images/pubsub-swagger.png)
 
-9. Enter the swagger url (eg: for PubSub <https://invictus-dev-we-sft-pubsubapp.azurewebsites.net/swagger/docs/v1>).
+9. Enter the swagger url (eg: for PubSub <a href="">https://invictus-dev-we-sft-pubsubapp.azurewebsites.net/swagger/docs/v1</a>).
 
    ![swagger connector](../../../images/pubsub-swaggerconnector.png)
 


### PR DESCRIPTION
When migrating possibly to Docusaurus, it fails on creating Markdown links on the following. This PR fixes these with an empty HTML `<a href="/">...</a>` instead.