### PR TITLE
fix(md.code): add/correct markdown code style for framework component

### DIFF
--- a/framework/components/regextranslation.md
+++ b/framework/components/regextranslation.md
@@ -40,10 +40,12 @@ Within the table 2 properties of type string have to be added when creating a ne
 
 ### Sample Request Schema
 
-`{
+```json
+{
   "Content": "The provided host name 'website.com' could not be resolved",
   "MatchKey": ["OrderService", "InvoiceService"]
-}`
+}
+```
 
 When setting up your Logic App, the HttpRequest is to be setup as follows:
 
@@ -57,15 +59,19 @@ The request is then followed by the execution of the function **RegexTranslation
 
 After the message is translated, the result for a successful translation returns the translated message:
 
-`{
+```json
+{
     "content": "System X could not be reached at endpoint 'website.com', contact John"
-}`
+}
+```
 
 If the translation is unsuccessful, the output returned will either be the original message or specific error message:
 
-`{
+```json
+{
     "content": "The provided host name website.com could not be resolved"
-}`
+}
+```
 
 The response to the function **RegexTranslation** is to be setup as follows:
 

--- a/framework/components/timesequencer.md
+++ b/framework/components/timesequencer.md
@@ -43,7 +43,7 @@ CompleteExecution is used to complete a request and to trigger any pending webho
 
 POST Request Object:
 
-```
+```json
 {
  "instanceId": "[STRING]", //The ID associated to the request. SequenceName and InstanceId form the PrimaryKey for the request
  "sequenceName": "[STRING]"The ID used to group requests together, //SequenceName and InstanceId form the PrimaryKey for the request

--- a/framework/components/transcoV2-Example.md
+++ b/framework/components/transcoV2-Example.md
@@ -5,24 +5,25 @@ The following is a full example which demonstrates the usage of Transco V2.
 **Example DB Setup**
 
 In your DB of choice execute the following script:
-
-    CREATE TABLE [dbo].[Customers]
-    (
-    	[CustomerId] int NOT NULL,
-    	[CustomerName] nvarchar(100) NOT NULL,
-    	[CustomerAge] int NOT NULL,
-    	[CustomerStatus] nvarchar(100) NOT NULL,
-    	[Active] bit NOT NULL
-    )
-    
-    INSERT INTO [dbo].[Customers] (CustomerId, CustomerName, CustomerAge, CustomerStatus, Active)
-    VALUES (1, 'John Doe', 35, 'Member', 1)
-    
-    INSERT INTO [dbo].[Customers] (CustomerId, CustomerName, CustomerAge, CustomerStatus, Active)
-    VALUES (2, 'Mary Smith', 56, 'Member', 0)
-    
-    INSERT INTO [dbo].[Customers] (CustomerId, CustomerName, CustomerAge, CustomerStatus, Active)
-    VALUES (3, 'Mike Brown', 29, 'Non-Member', 1)
+```sql
+ CREATE TABLE [dbo].[Customers]
+ (
+ 	[CustomerId] int NOT NULL,
+ 	[CustomerName] nvarchar(100) NOT NULL,
+ 	[CustomerAge] int NOT NULL,
+ 	[CustomerStatus] nvarchar(100) NOT NULL,
+ 	[Active] bit NOT NULL
+ )
+ 
+ INSERT INTO [dbo].[Customers] (CustomerId, CustomerName, CustomerAge, CustomerStatus, Active)
+ VALUES (1, 'John Doe', 35, 'Member', 1)
+ 
+ INSERT INTO [dbo].[Customers] (CustomerId, CustomerName, CustomerAge, CustomerStatus, Active)
+ VALUES (2, 'Mary Smith', 56, 'Member', 0)
+ 
+ INSERT INTO [dbo].[Customers] (CustomerId, CustomerName, CustomerAge, CustomerStatus, Active)
+ VALUES (3, 'Mike Brown', 29, 'Non-Member', 1)
+```
 
 **Transco Request**
 
@@ -31,114 +32,120 @@ In your DB of choice execute the following script:
 The below Transco config is used to obtain the Customer Status from the DB and insert it into the XML Content. Then the content is transformed according to the defined XSLT file.
 
 *XML Content (decoded)*
-
-    <?xml version="1.0" ?>
-    <persons>
-    	<header>Person Customers</header>
-    	<person>
-    		<name>John Doe</name>
-    		<status></status>
-    	</person>
-    	<person>
-    		<name>Mike Brown</name>
-    		<status></status>
-    	</person>
-    </persons>
+```xml
+<?xml version="1.0" ?>
+<persons>
+	<header>Person Customers</header>
+	<person>
+		<name>John Doe</name>
+		<status></status>
+	</person>
+	<person>
+		<name>Mike Brown</name>
+		<status></status>
+	</person>
+</persons>
+```
 
 *docsexample.config*
-
+```json
+{
+  "instructions": [
     {
-      "instructions": [
-        {
-          "type": "xml",
-          "scopePath": "/persons/person",
-          "destination": "status",
-          "command": {
-            "databaseKeyVaultName": "transcodb",
-            "commandValue": "SELECT CustomerStatus FROM dbo.Customers WHERE CustomerName = @Name AND Active = @Active",
-            "isMandatory": true,
-            "defaultValue": "0",
-            "parameters": [
-              {
-                "paramName": "Name",
-                "value": "name",
-                "type": "nvarchar",
-                "valueType": "path"
-              },
-              {
-                "paramName": "Active",
-                "value": "CustomerActive",
-                "type": "bit",
-                "valueType": "context"
-              }
-            ],
-            "cache": {
-              "useCaching": true,
-              "cachingTimeout": "01:30:15"
-            }
+      "type": "xml",
+      "scopePath": "/persons/person",
+      "destination": "status",
+      "command": {
+        "databaseKeyVaultName": "transcodb",
+        "commandValue": "SELECT CustomerStatus FROM dbo.Customers WHERE CustomerName = @Name AND Active = @Active",
+        "isMandatory": true,
+        "defaultValue": "0",
+        "parameters": [
+          {
+            "paramName": "Name",
+            "value": "name",
+            "type": "nvarchar",
+            "valueType": "path"
+          },
+          {
+            "paramName": "Active",
+            "value": "CustomerActive",
+            "type": "bit",
+            "valueType": "context"
           }
-        },
-        {
-          "xsltTransform": "docsexample.xslt",
-          "extensions": []
-        }
-      ],
-      "options": {
-        "configCache": {
-          "useCaching": false,
-          "cachingTimeout": "01:30:00"
+        ],
+        "cache": {
+          "useCaching": true,
+          "cachingTimeout": "01:30:15"
         }
       }
+    },
+    {
+      "xsltTransform": "docsexample.xslt",
+      "extensions": []
     }
-
+  ],
+  "options": {
+    "configCache": {
+      "useCaching": false,
+      "cachingTimeout": "01:30:00"
+    }
+  }
+}
+```
 
 
 *docsexample.xslt*
+```xslt
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="xml" indent="yes"/>
 
-    <?xml version="1.0" encoding="UTF-8"?>
-    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-      <xsl:output method="xml" indent="yes"/>
-    
-      <xsl:template match="/persons">
-        <root>
-          <xsl:apply-templates select="person"/>
-        </root>
-      </xsl:template>
-    
-      <xsl:template match="person">
-        <name status="{status}">
-          <xsl:value-of select="name" />
-        </name>
-      </xsl:template>
-    
-    </xsl:stylesheet>
+  <xsl:template match="/persons">
+    <root>
+      <xsl:apply-templates select="person"/>
+    </root>
+  </xsl:template>
+
+  <xsl:template match="person">
+    <name status="{status}">
+      <xsl:value-of select="name" />
+    </name>
+  </xsl:template>
+
+</xsl:stylesheet>
+```
 
 A POST request is sent to the Transco function URL and endpoint */api/TranscoXML* with the following Body. An application such as Postman can be used for this.
 
 ![Postman Request](../../images/transcoV2Postman.png)
 
-
-    {   
-	    "Content": "PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8cGVyc29ucz4KCTxoZWFkZXI+UGVyc29uIEN1c3RvbWVyczwvaGVhZGVyPgoJPHBlcnNvbj4KCQk8bmFtZT5Kb2huIERvZTwvbmFtZT4KCQk8c3RhdHVzPjwvc3RhdHVzPgoJPC9wZXJzb24+Cgk8cGVyc29uPgoJCTxuYW1lPk1pa2UgQnJvd248L25hbWU+CgkJPHN0YXR1cz48L3N0YXR1cz4KCTwvcGVyc29uPgo8L3BlcnNvbnM+",    
-	    "Context": {
-		    "CustomerActive": "true"   
-	    },   
-	    "TranscoConfig": "docsexample.config.json"  
-    }
+```json
+{   
+ "Content": "PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8cGVyc29ucz4KCTxoZWFkZXI+UGVyc29uIEN1c3RvbWVyczwvaGVhZGVyPgoJPHBlcnNvbj4KCQk8bmFtZT5Kb2huIERvZTwvbmFtZT4KCQk8c3RhdHVzPjwvc3RhdHVzPgoJPC9wZXJzb24+Cgk8cGVyc29uPgoJCTxuYW1lPk1pa2UgQnJvd248L25hbWU+CgkJPHN0YXR1cz48L3N0YXR1cz4KCTwvcGVyc29uPgo8L3BlcnNvbnM+",    
+ "Context": {
+  "CustomerActive": "true"   
+ },   
+ "TranscoConfig": "docsexample.config.json"  
+}
+```
 
 Expected Response:
+```json
+{
+ "Content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTE2Ij8+PHJvb3Q+PG5hbWUgc3RhdHVzPSJNZW1iZXIiPkpvaG4gRG9lPC9uYW1lPjxuYW1lIHN0YXR1cz0iTm9uLU1lbWJlciI+TWlrZSBCcm93bjwvbmFtZT48L3Jvb3Q+",
+ "Context": {
+  "CustomerActive": "true"
+ },
+ "TranscoConfig": "docsexample.config.json"
+}
+```
 
-    {
-	    "Content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTE2Ij8+PHJvb3Q+PG5hbWUgc3RhdHVzPSJNZW1iZXIiPkpvaG4gRG9lPC9uYW1lPjxuYW1lIHN0YXR1cz0iTm9uLU1lbWJlciI+TWlrZSBCcm93bjwvbmFtZT48L3Jvb3Q+",
-	    "Context": {
-		    "CustomerActive": "true"
-	    },
-	    "TranscoConfig": "docsexample.config.json"
-    }
 Decoded Response Content:
-
-    <?xml version="1.0" encoding="utf-16"?>
-    <root>
-        <name status="Member">John Doe</name>
-        <name status="Non-Member">Mike Brown</name>
-    </root>
+```xml
+<?xml version="1.0" encoding="utf-16"?>
+<root>
+    <name status="Member">John Doe</name>
+    <name status="Non-Member">Mike Brown</name>
+</root>
+```

--- a/framework/components/transcoV2-Matrix.md
+++ b/framework/components/transcoV2-Matrix.md
@@ -32,68 +32,70 @@ Each key-value pair in the KeyValueCollection is individually promoted to the co
 
 
 Example Request:
-
-    {
-	    "Content":  "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
-	    "Context":  {
-	    "x-conversationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",
-	    "x-correlationId":  "fc13d345-ebd7-44f2-89a9-4371258c0a08",
-	    "x-batchId":  "975f7ea4-6247-431b-afb6-6d27fb47516f",
-	    "x-applicationName":  "InvoiceApp",
-	    "filter":  "endtoendintegrationtests"	    
-	    },   
-	    "KeyValueCollection":  {
-		    "w":  3,
-		    "l":  10.2,
-		    "h":  1,
-		    "t":  200,
-	    },
-	    "Flow":  "fl1",
-	    "Domain":  "do",
-	    "Service":  "sr1",
-	    "Action":  "Ac",
-	    "Version":  "Vs",
-	    "Sender":  "Snd",
-	    "ApplicationName":  "Snd",
-	    "Milestone":  "2018",
-	    "ConversationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",   
-	    "CorrelationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0", 
-	    "BatchId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",  
-	    "Data1":  "d1", 
-	    "Data2":  "d2", 
-	    "Data3":  "d3"
-    }
+```json
+{
+ "Content":  "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
+ "Context":  {
+ "x-conversationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",
+ "x-correlationId":  "fc13d345-ebd7-44f2-89a9-4371258c0a08",
+ "x-batchId":  "975f7ea4-6247-431b-afb6-6d27fb47516f",
+ "x-applicationName":  "InvoiceApp",
+ "filter":  "endtoendintegrationtests"	    
+ },   
+ "KeyValueCollection":  {
+  "w":  3,
+  "l":  10.2,
+  "h":  1,
+  "t":  200,
+ },
+ "Flow":  "fl1",
+ "Domain":  "do",
+ "Service":  "sr1",
+ "Action":  "Ac",
+ "Version":  "Vs",
+ "Sender":  "Snd",
+ "ApplicationName":  "Snd",
+ "Milestone":  "2018",
+ "ConversationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",   
+ "CorrelationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0", 
+ "BatchId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",  
+ "Data1":  "d1", 
+ "Data2":  "d2", 
+ "Data3":  "d3"
+}
+```
 
 Expected Response:
-
-    {
-        "content": "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
-        "context": {
-            "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0",
-            "x-correlationId": "fc13d345-ebd7-44f2-89a9-4371258c0a08",
-            "x-batchId": "975f7ea4-6247-431b-afb6-6d27fb47516f",
-            "x-applicationName": "InvoiceApp",
-            "filter": "endtoendintegrationtests",
-            "Flow": "fl1",
-            "Domain": "do",	    
-            "Service": "sr1",
-            "Action": "Ac",
-            "Version": "Vs",
-            "ApplicationName": "Snd",
-            "Milestone": "2018",
-            "Data1": "d1",
-            "Data2": "d2",
-            "Data3": "d3",
-            "Sender": "Snd",
-            "w": 3,
-            "l": 10.2,
-            "h": 1,
-            "t": 200
-        },
-        "conversationId": null,
-        "correlationId": null,
-        "batchId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
-    }
+```json
+{
+    "content": "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
+    "context": {
+        "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0",
+        "x-correlationId": "fc13d345-ebd7-44f2-89a9-4371258c0a08",
+        "x-batchId": "975f7ea4-6247-431b-afb6-6d27fb47516f",
+        "x-applicationName": "InvoiceApp",
+        "filter": "endtoendintegrationtests",
+        "Flow": "fl1",
+        "Domain": "do",	    
+        "Service": "sr1",
+        "Action": "Ac",
+        "Version": "Vs",
+        "ApplicationName": "Snd",
+        "Milestone": "2018",
+        "Data1": "d1",
+        "Data2": "d2",
+        "Data3": "d3",
+        "Sender": "Snd",
+        "w": 3,
+        "l": 10.2,
+        "h": 1,
+        "t": 200
+    },
+    "conversationId": null,
+    "correlationId": null,
+    "batchId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
+}
+```
 
 ## Transco Support
 

--- a/framework/components/transcoV2.md
+++ b/framework/components/transcoV2.md
@@ -47,7 +47,7 @@ See [Transco V2 - Matrix Functionality](https://github.com/invictus-integration/
 A JSON Transco config file is required to specify details about the instruction which will be performed. Instructions are executed in the order in which they appear. The name of the config file should be specified in the request so that it can be retrieved from the storage account.
 
 **Config File Full Specification:**
-
+	```json
     {
     	"instructions": [
     		{
@@ -115,19 +115,22 @@ A JSON Transco config file is required to specify details about the instruction 
                      "indentResult": [If true, transco results will be formatted and indented]
     	}
     }
+	```
 
 **SQL Command Instruction**
 
 This instruction can be added to the Transco config to promote values from the database into XML or JSON content, or into the request Context. Scope path can be defined so that the command affects only nodes within that path. In the command section, a connection to the DB must be provided either via a connection string or via the Key Vault secret name. The SQL query itself is also defined in this section. Parameters in the SQL query must be denoted with an '@' symbol. Parameters may be given a name or indexed with a number.
 
 Example:
-*SELECT CustomerStatus FROM dbo.Customers WHERE CustomerName = @Name AND Active = @Active*
-
+```sql
+SELECT CustomerStatus FROM dbo.Customers WHERE CustomerName = @Name AND Active = @Active*
+```
 or
+```sql
+SELECT CustomerStatus FROM dbo.Customers WHERE CustomerName = @1 AND Active = @2*
+```
 
-*SELECT CustomerStatus FROM dbo.Customers WHERE CustomerName = @1 AND Active = @2*
-
-
+	```json
     {
     	"scopePath": [XPath/JPath of content scope],
     	"namespaces": [
@@ -170,12 +173,13 @@ or
     				}
     	}
     }
+	```
 
 **XML Transform Instruction**
 This instruction can be added to the Transco Config to transform XML content via the specified XSLT file. Assemblies and dependencies used by the XSLT transformation are also specified in this instruction so that they may downloaded from storage and loaded for use by Transco.
 
 This instruction is only available when calling the /TranscoXML endpoint.
-
+	```json
     {
 	    "xsltTransform": [Name of XSLT file],
 	    "extensions": [
@@ -190,6 +194,7 @@ This instruction is only available when calling the /TranscoXML endpoint.
 		    }
 	    ]
     }
+	```
 
 ## Storage Account
 
@@ -213,7 +218,7 @@ The Transco request requires three values:
  3. Name of transco config file in storage account
 
 Example payload:
-
+	```json
     {
 	    "Content":  "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTE2Ij8+PHJvb3Q+PG5hbWUgc3RhdHVzPSJNZW1iZXIiPkpvaG4gRG9lPC9uYW1lPjwvcm9vdD4=",
 	    "Context":  {
@@ -221,6 +226,7 @@ Example payload:
 	    }, 
 	    "TranscoConfig":  "docs_config.json"    
     }
+	```
 
 ## Creating Logic App with TranscoV2 Connector
 

--- a/framework/components/xmljsonconverter.md
+++ b/framework/components/xmljsonconverter.md
@@ -19,7 +19,7 @@ This framework component can be used to transform either XML to JSON or JSON to 
 |JPath|No|Used to focus on part of the content/result|
 
 ### Sample Request Schema
-
+```json
 {
 "configName":"IDD038-inbound.xsl",
 "content": "eyJFbnZlbG9wZSI6IHiU2FsZXNPcmRlckluIjp7ICAgICAgICAg...." 
@@ -27,6 +27,7 @@ This framework component can be used to transform either XML to JSON or JSON to 
 "xpath": "",
 "jpath" "$.Envelope"
 }
+```
 
 ### Config
 


### PR DESCRIPTION
Several Framework components used none or incomplete Markdown code style. This PR adds the missing styles so that we also also have (later) clear syntactic coloring + correct Markdown>HTML conversion when considering Docusaurs.