### PR TITLE
chore(fsidebar): incorporate framework overview into components title

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -26,7 +26,7 @@
       * [Auditing](/dashboard/auditing.md)
     * Other
       * [Settings](/dashboard/settings.md)
-* [Framework components](/framework/framework.md)
+* [Framework components](/framework/framework.md )
   * [Installation](/framework/installation/framework-installation.md)
   * [Deprecated components](/framework/components/deprecated/deprecated-components.md)
   * Active components

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -26,8 +26,7 @@
       * [Auditing](/dashboard/auditing.md)
     * Other
       * [Settings](/dashboard/settings.md)
-* Framework components
-  * [Overview](/framework/framework.md)
+* [Framework components](/framework/framework.md)
   * [Installation](/framework/installation/framework-installation.md)
   * [Deprecated components](/framework/components/deprecated/deprecated-components.md)
   * Active components

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -26,7 +26,7 @@
       * [Auditing](/dashboard/auditing.md)
     * Other
       * [Settings](/dashboard/settings.md)
-* [Framework components](/framework/framework.md )
+* [Framework components](/framework/framework.md)
   * [Installation](/framework/installation/framework-installation.md)
   * [Deprecated components](/framework/components/deprecated/deprecated-components.md)
   * Active components


### PR DESCRIPTION
To continue simplifying the sidebar, we can incorporate the 'Framework overview' into the currently unused 'Framework components', making it much easier to navigate/grasp the navigation.