### PR TITLE
chore(role): improve language description on flows in role management

### DIFF
--- a/dashboard/role-management.md
+++ b/dashboard/role-management.md
@@ -17,17 +17,17 @@ Permissions in the Invictus Dashboard are separated into two categories: user ro
   | CRUD alerts          | 🔴          | 🟢            |
   | CRUD folder/flows    | 🟡          | 🟢            |
   | View audits          | 🔴          | 🟢            |
-  | View flow data       | 🟡          | 🟢            |
+  | View flow traces     | 🟡          | 🟢            |
   | View statistics      | 🟢          | 🟢            |
 
 
-* **Folder permissions**: Anything folder- or flow-related is authorized with a more fine-grained role management system for *Non admin* users/groups.
+* **Flow permissions**: Anything folder- or flow-related is authorized with a more fine-grained role management system for *Non admin* users/groups.
 
   | Folder functionality     | Reader   | Operator   | Folder admin   |
   | ------------------------ | :------: | :--------: | :------------: |
   | CRUD folder/flows        | 🔴       | 🔴        | 🟢             |
-  | Grant folder permissions | 🔴       | 🔴        | 🟢             |
-  | Execute flows*           | 🔴       | 🟢        | 🟢             |
+  | Grant flow permissions   | 🔴       | 🔴        | 🟢             |
+  | Operations on flows*     | 🔴       | 🟢        | 🟢             |
   | View folder/flows        | 🟢       | 🟢        | 🟢             |
 
 > \* *Flows can be resubmitted, resumed, and ignored via the Dashboard.*


### PR DESCRIPTION
To streamline the recent changes on 'flow traces' (instead of 'flow data', as this is a technical name that was used for the `FlowData` model in Cosmos, but has no added-value). Furthermore, this PR also lets the focus on 'flows' instead of 'folders' as from a user-perspective, you want to grant permissions to flows, not folders, per se.