### PR TITLE
chore(installation): mark parameterized/customization in installation docs as code lang

### DIFF
--- a/dashboard/installation/dashboard-buildpipeline.md
+++ b/dashboard/installation/dashboard-buildpipeline.md
@@ -4,7 +4,7 @@ To deploy the Invictus Dashboard together with your customer solution, the first
 ## 1. Save `Invictus-GetSources.ps1` script to your repository
 The `Invictus-GetSources.ps1` script will pull the latest Invictus resources needed to deploy the Dashboard.
 
-> [⬇️`Invictus-GetSources.ps1`](https://github.com/invictus-integration/docs-ifa/blob/containerization/dashboard/installation/scripts/Invictus-GetSources.ps1)
+> [⬇️`Invictus-GetSources.ps1`](https://github.com/invictus-integration/docs-ifa/blob/master/dashboard/installation/scripts/Invictus-GetSources.ps1)
 
 ## 2. Add variables to variable group.
 To deploy Invictus, you will need some secrets for authentication. These secrets should be provided to you by **Codit Software**.

--- a/dashboard/installation/dashboard-buildpipeline.md
+++ b/dashboard/installation/dashboard-buildpipeline.md
@@ -9,7 +9,7 @@ The `Invictus-GetSources.ps1` script will pull the latest Invictus resources nee
 ## 2. Add variables to variable group.
 To deploy Invictus, you will need some secrets for authentication. These secrets should be provided to you by **Codit Software**.
 
-Once you have obtained these values, create a variable group named {prefix}.Invictus.Installation and add the below variables.
+Once you have obtained these values, create a variable group named `{prefix}.Invictus.Installation` and add the below variables.
 
 - **Invictus.Installation.StorageAccount.Name**: invictusreleases
 - **Invictus.Installation.StorageAccount.Dashboard.SasToken**: value provided by Codit Software

--- a/dashboard/installation/dashboard-releasepipeline.md
+++ b/dashboard/installation/dashboard-releasepipeline.md
@@ -8,7 +8,7 @@ The release uses variable groups and edits/adds variables to the groups, we will
 
 ## Variable Group
 
-Create a variable group named {prefix}.Invictus.{stage} for all the stages (environments) and add at least one variable (eg: Invictus.Secrets.ApiKey1.Name = apikey1).
+Create a variable group named `{prefix}.Invictus.{stage}` for all the stages (environments) and add at least one variable (eg: Invictus.Secrets.ApiKey1.Name = apikey1).
 
 Make sure the Project Collection Build Service has Administrator access to these variable groups (Pipelines > Library > Security)
 
@@ -185,6 +185,12 @@ Parameters related to the applications that are deployed, mostly Azure Functions
 | ------------------------------------------ | :------: | ------- | ------------------------------------------------------------------------ |
 | `statisticsCutOffDays`                     | No       | `-3`    | The number of days in the past that homepage statistics will recalculate |
 
+| Parameter                           | Required | Default                        | Description                                                   |
+| ----------------------------------- | :------: | ------------------------------ | ------------------------------------------------------------- |
+| `servicePlanName`                   | No       | `invictus-{resourcePrefix}-appplan-linux` | Name for the service plan which will host the APIs |
+| `servicePlanSkuName`                | No       | S1                              | Size for the App Plan, the value of "I1" needs to be passed to install an isolated plan.|
+| `servicePlanSkuCapacity`            | No       | `1`                             | The SKU capacity setting for the App Plan   |
+
 ## Storage parameters
 Parameters related to the data that is stored throughout Invictus.
 
@@ -218,9 +224,6 @@ Parameters related to the messaging resources that import the flow information i
 | ----------------------------------- | :------: | ------------------------------- | -------------------------------------------------------- |
 | `serviceBusNamespaceName`           | No       | `invictus-{resourcePrefix}-sbs` | Name for the Service Bus Namespace resource |
 | `serviceBusSkuName`                 | No       | Standard or Premium if VNET enabled | Name for the Service Bus SKU |
-| `servicePlanName`                   | No       | `invictus-{resourcePrefix}-appplan-linux` | Name for the service plan which will host the APIs |
-| `servicePlanSkuName`                | No       | S1                              | Size for the App Plan, the value of "I1" needs to be passed to install an isolated plan.|
-| `servicePlanSkuCapacity`            | No       | `1`                             | The SKU capacity setting for the App Plan   |
 | **`serviceBusSubnets` (VNET)**      | **Yes**  | **`[]`**                       | **An array of string. The values need to match the subnet names on the VNET** |
 
 | Parameter                           | Required | Default                             | Description                               |

--- a/dashboard/installation/dashboard-vnet.md
+++ b/dashboard/installation/dashboard-vnet.md
@@ -17,16 +17,16 @@ Invictus includes functionality which allows all its resources to run within an 
   - The container app subnet must also have the delegation `Microsoft.App/environments` ([more info](https://learn.microsoft.com/en-us/azure/virtual-network/manage-subnet-delegation))
         
 - 10 Private DNS Zones
-  - privatelink.azurecr.io
-  - privatelink.blob.core.windows.net
-  - privatelink.file.core.windows.net
-  - privatelink.mongo.cosmos.azure.com
-  - privatelink.queue.core.windows.net
-  - privatelink.servicebus.windows.net
-  - privatelink.table.core.windows.net
-  - privatelink.table.cosmos.azure.com
-  - privatelink.vaultcore.azure.net
-  - privatelink.{regionName}.azurecontainerapps.io
+  - `privatelink.azurecr.io`
+  - `privatelink.blob.core.windows.net`
+  - `privatelink.file.core.windows.net`
+  - `privatelink.mongo.cosmos.azure.com`
+  - `privatelink.queue.core.windows.net`
+  - `privatelink.servicebus.windows.net`
+  - `privatelink.table.core.windows.net`
+  - `privatelink.table.cosmos.azure.com`
+  - `privatelink.vaultcore.azure.net`
+  - `privatelink.{regionName}.azurecontainerapps.io`
     
   A Bicep template for these DNS Zones can be found [here](scripts/invictusVnetDNSZones.bicep)
 

--- a/framework/installation/framework-buildpipeline.md
+++ b/framework/installation/framework-buildpipeline.md
@@ -8,7 +8,7 @@ The pipeline will use variables stored in a variable group, so before creating t
 
 ## Variable Group
 
-Create a variable group named {prefix}.Invictus.Installation and add these variables:
+Create a variable group named `{prefix}.Invictus.Installation` and add these variables:
 
 - **Invictus.Installation.StorageAccount.Name**: invictusreleases
 - **Invictus.Installation.StorageAccount.Dashboard.SasToken**: value provided by Codit Software

--- a/framework/installation/framework-buildpipeline.md
+++ b/framework/installation/framework-buildpipeline.md
@@ -2,7 +2,7 @@
 
 # Framework Build Pipeline
 
-The build pipeline uses a powershell script to pull the resources needed for the release. This script can be downloaded from [here](https://github.com/invictus-integration/docs-ifa/blob/containerization/dashboard/installation/scripts/Invictus-GetSources.ps1). Make sure to include it in your Git repository (e.g. in the deploy folder).
+The build pipeline uses a powershell script to pull the resources needed for the release. This script can be downloaded from [here](https://github.com/invictus-integration/docs-ifa/blob/master/dashboard/installation/scripts/Invictus-GetSources.ps1). Make sure to include it in your Git repository (e.g. in the deploy folder).
 
 The pipeline will use variables stored in a variable group, so before creating the build pipeline open the DevOps Library page and create a new variable group.
 

--- a/framework/installation/framework-releasepipeline.md
+++ b/framework/installation/framework-releasepipeline.md
@@ -6,7 +6,7 @@ The release pipeline will use the artifacts created from the build pipeline and 
 
 ## Variable Group
 
-Create a variable group named {prefix}.Invictus.{stage} for all the stages (environments) and add at least one variable (eg: Invictus.Secrets.ApiKey1.Name = apikey1).
+Create a variable group named `{prefix}.Invictus.{stage}` for all the stages (environments) and add at least one variable (eg: Invictus.Secrets.ApiKey1.Name = apikey1).
 
 Make sure the Project Collection Build Service has Administrator access to these variable groups (Pipelines > Library > Security)
 
@@ -75,46 +75,77 @@ PS> $(ArtifactsPath)/Deploy.ps1 `
 
 ## Bicep Template Parameters
 
-The below table lists the parameters accepted by the Bicep template.
+The below tables lists the parameters accepted by the Bicep template.
 
-|Parameter Name|Required|Default Value|Description|
-| --- | :---: | --- | --- |
-|resourcePrefix|Yes||used as part of the default names for most resources.|
-|timesequencerFunctionName|No|invictus-{resourcePrefix}-timesequencer|Name for the time sequencer function|
-|sequenceControllerFunctionName|No|invictus-{resourcePrefix}-sequencecontroller|Name for the Sequence Controller function|
-|xmlJsonConverterFunctionName|No|invictus-{resourcePrefix}-xmljsonconverter|Name for the XmlJson Converter function|
-|xsdValidatorFunctionName|No|invictus-{resourcePrefix}-xsdvalidator|Name for the XSD Validator function|
-|regexTranslatorFunctionName|No|invictus-{resourcePrefix}-regextranslator|Name for the Regex Translator function|
-|transcoV2FunctionName|No|invictus-{resourcePrefix}-transco-v2|Name for the TranscoV2 function|
-|pubsubV2FunctionName|No|invictus-{resourcePrefix}-pubsub-v2|Name for the PubSubV2 function|
-|exceptionHandlerFunctionName|No|invictus-{resourcePrefix}-exceptionhandler|Name for the Exception Handler function|
-|serviceBusNamespaceName|No|invictus-{resourcePrefix}-sbs|Name for the Service Bus Namespace resource|
-|serviceBusSkuName|No|Standard or Premium if VNET enabled|Name for the Service Bus SKU|
-|keyVaultName|No|invictus-{resourcePrefix}-vlt|Name for the Key Vault Service Namespace resource|
-|keyVaultEnablePurgeProtection|No|null|If true, enables key vault purge protection. Once enabled, this property can never be disabled.|
-|storageAccountName|No|invictus{resourcePrefix}store|Name for the Azure Storage resource. Any dashes (-) will be removed from {resourcePrefix}|
-|blobContainerPrefix|No|invictus|Prefix set for blob containers for pubsub|
-|appInsightsName|No|invictus-{resourcePrefix}-appins|Name for the Application Insights resource|
-|servicePlanName|No|invictus-{resourcePrefix}-appplan|Name for the service plan which will host the APIs|
-|serviceBusMessageTimeToLiveMinutes|No|-1|Time messages should be stored on service bus before being archived|
-|storageAccountType|No|Standard_LRS|The Storage account StorageAccountSkuType|
-|devOpsObjectId|Yes||The object-id associated with the service principal of the enterprise application that's connected to the service connection on DevOps|
-|identityProviderClientSecret|Yes||AAD App Registration client secret required for Azure Container Apps Identity Provider authentication|
-|identityProviderApplicationId|Yes||AAD Application ID for MSI Authentication of Azure Container Apps|
+## Top-level parameters
+Resource-independent parameters that affect all resources in the deployed resource group.
 
-### VNET Specific Parameters
+| Parameter        | Required | Default | Description          |
+| ---------------- | :------: | --------| -------------------- |
+| `resourcePrefix` | Yes      |         | used as part of the default names for most resources. |
+| `devOpsObjectId` | Yes      |         | The object-id associated with the service principal of the enterprise application that's connected to the service connection on DevOps |
 
-|Parameter Name|Required for VNET|Default Value|Description|
-| --- | :---: | --- | --- |
-|enableVnetSupport|Yes|false|Used to toggle VNET functionality on or off|
-|vnetResourceGroupName|Yes|&nbsp;|The name of the resource group on Azure where the VNET is located|
-|vnetName|Yes|&nbsp;|The name of the VNET resource|
-|keyVaultSubnets|Yes|[]|An array of string. The values need to match the subnet names on the VNET|
-|storageAccountSubnets|Yes|[]|An array of string. The values need to match the subnet names on the VNET|
-|serviceBusSubnets|Yes|[]|An array of string. The values need to match the subnet names on the VNET|
-|privateEndpointSubnetName|Yes||The name of the subnet to be used to connect the private endpoint resources|
-|containerAppEnvironmentSubnetName|Yes|                               |The name of the subnet to be used to connect the container app environment|
-|disableStorageAccountPublicNetworkAccess|No|false|If true, the Invictus storage account will not be accessible from a public network.|
-|storageAccountMinimumTLSVersion |No|TLS1_2|Set the required TLS value for the storage account. Accepted values: TLS1_0, TLS1_1, TLS1_2|
-|dnsZoneSubscriptionId|No|Subscription ID of scope|The subscription ID of the private DNS zones.|
-|dnsZoneResourceGroupName|No|VNET RG name|The resource group name of where the private DNS zones are located.|
+| Parameter                                     | Required | Default | Description          |
+| --------------------------------------------- | :------: | ------- | -------------------- |
+| **`enabledVnetSupport` (VNET)**               | Yes      | `false` | Used to toggle VNET functionality on or off |
+| **`vnetResourceGroupName` (VNET)**            | Yes      | &nbsp;  | The name of the resource group on Azure where the VNET is located |
+| **`vnetName` (VNET)**                         | Yes      | &nbsp;  | The name of the VNET resource |
+|**`privateEndpointSubnetName` (VNET)**         | Yes      |         |The name of the subnet to be used to connect the private endpoint resources|
+|**`containerAppEnvironmentSubnetName` (VNET)** | Yes      |         |The name of the subnet to be used to connect the container app environment|
+|**`dnsZoneSubscriptionId` (VNET)**             | No       | Subscription ID of scope | The subscription ID of the private DNS zones.|
+|**`dnsZoneResourceGroupName` (VNET)**          | No       | VNET RG name             | The resource group name of where the private DNS zones are located.|
+
+## Function App service parameters
+Parameters related to the Azure Functions applications that are deployed.
+
+| Parameter                         | Required | Default                                        | Description                 |
+| --------------------------------- | :------: | ---------------------------------------------- | --------------------------- |
+| `timesequencerFunctionName`       | No       | `invictus-{resourcePrefix}-timesequencer`      | Name for the time sequencer function|
+| `sequenceControllerFunctionName`  | No       | `invictus-{resourcePrefix}-sequencecontroller` | Name for the Sequence Controller function|
+| `xmlJsonConverterFunctionName`    | No       | `invictus-{resourcePrefix}-xmljsonconverter`   | Name for the XmlJson Converter function|
+| `xsdValidatorFunctionName`        | No       | `invictus-{resourcePrefix}-xsdvalidator`       | Name for the XSD Validator function|
+| `regexTranslatorFunctionName`     | No       | `invictus-{resourcePrefix}-regextranslator`    | Name for the Regex Translator function|
+| `transcoV2FunctionName`           | No       | `invictus-{resourcePrefix}-transco-v2`         | Name for the TranscoV2 function|
+| `pubsubV2FunctionName`            | No       | `invictus-{resourcePrefix}-pubsub-v2`          | Name for the PubSubV2 function|
+| `exceptionHandlerFunctionName`    | No       | `invictus-{resourcePrefix}-exceptionhandler`   | Name for the Exception Handler function|
+| `servicePlanName`                 | No       | `invictus-{resourcePrefix}-appplan`            | Name for the service plan which will host the APIs|
+
+## Storage parameters
+Parameters related to data that is stored during the component's interaction.
+
+| Parameter             | Required | Default                             | Description               |
+| ----------------------| :------: | ------------------------------------| ------------------------- |
+| `storageAccountName`  | No       | `invictus{resourcePrefix}store`     | Name for the Azure Storage resource. Any dashes (-) will be removed from `{resourcePrefix}`|
+| `blobContainerPrefix` | No       | `invictus`                          | Prefix set for blob containers for pubsub|
+| `storageAccountType`  | No       | `Standard_LRS`                      | The Storage account StorageAccountSkuType|
+| **`storageAccountSubnets` (VNET)**                    | Yes | `[]`     | An array of string. The values need to match the subnet names on the VNET|
+| **`disableStorageAccountPublicNetworkAccess` (VNET)** | No  | `false`  | If true, the Invictus storage account will not be accessible from a public network.|
+| **`storageAccountMinimumTLSVersion` (VNET)**          | No  | `TLS1_2` | Set the required TLS value for the storage account. Accepted values: `TLS1_0`, `TLS1_1`, `TLS1_2`|
+
+## Messaging parameters
+Parameters related to the messaging components, like PubSub.
+
+| Parameter                            | Required | Default | Description |
+| ------------------------------------ | :------: | ------- | ----------- |
+| `serviceBusNamespaceName`            | No       | `invictus-{resourcePrefix}-sbs` | Name for the Service Bus Namespace resource|
+| `serviceBusSkuName`                  | No       | `Standard` or `Premium` if VNET enabled` | Name for the Service Bus SKU|
+| `serviceBusMessageTimeToLiveMinutes` | No       | `-1`    | Time messages should be stored on service bus before being archived|
+|**`serviceBusSubnets` (VNET)**        | Yes      | `[]`    | An array of string. The values need to match the subnet names on the VNET|
+
+## Secret parameters
+Parameters related to the security and secret management of the deployed applications. 
+
+| Parameter                       | Required | Default | Description              |
+| ------------------------------- | :------: | ------- | ------------------------ |
+| `keyVaultName`                  | No       | `invictus-{resourcePrefix}-vlt` |Name for the Key Vault Service Namespace resource|
+| `keyVaultEnablePurgeProtection` | No       | `null`  | If true, enables key vault purge protection. Once enabled, this property can never be disabled.|
+| `identityProviderClientSecret`  | Yes      |         | AAD App Registration client secret required for Azure Container Apps Identity Provider authentication|
+| `identityProviderApplicationId` | Yes      |         | AAD Application ID for MSI Authentication of Azure Container Apps|
+| **`keyVaultSubnets` (VNET)**    | Yes      | `[]`    | An array of string. The values need to match the subnet names on the VNET|
+
+## Observability parameters
+Parameters related to telemetry tracking of the deployed applications.
+
+| Parameter         | Required | Default | Description       |
+| ----------------- | :------: | --------| ----------------- |
+| `appInsightsName` | No       | `invictus-{resourcePrefix}-appins` | Name for the Application Insights resource|

--- a/framework/installation/framework-vnet.md
+++ b/framework/installation/framework-vnet.md
@@ -2,4 +2,4 @@
 
 Enabling Azure Virtual Network support for the Invictus Framework is an identical process as for the Invictus Dashboard. Therefore you can follow the same guide found [here](../../dashboard/installation/dashboard-vnet.md).
 
-A full list of VNET specific parameters which can be passed to Framework release pipeline can be found [here](framework-releasepipeline.md#vnet-specific-parameters).
+A full list of VNET specific parameters which can be passed to Framework release pipeline can be found [here](framework-releasepipeline.md).


### PR DESCRIPTION
Docusaurus fails on things like: {prefix} as it assumes they are variables. Also for readability, we should mark them as 'code' in Markdown: `{prefix}`.

This PR does this for all dashboard/framework installation feature docs.