### PR TITLE
chore(pipelines): remove direct /pipelines folder ref link

### DIFF
--- a/framework/installation/framework-buildpipeline.md
+++ b/framework/installation/framework-buildpipeline.md
@@ -17,8 +17,7 @@ Create a variable group named `{prefix}.Invictus.Installation` and add these var
 Once you have the variable group, we can now proceed to creating the build pipeline.
 
 ## YAML Pipeline
-Add the files and folders from [this](./pipelines) location to your DevOps repo. 
-This contains an example YAML pipelines to build the Invictus for Azure Framework, change the [framework.build.yaml](./pipelines/framework.build.yaml) file according to your needs, for example change the trigger path:
+Next step is to add YAML pipelines to build the Invictus for Azure Framework. Change the [framework.build.yaml](./pipelines/framework.build.yaml) file according to your needs, for example change the trigger path:
 ``` yaml
   paths:
     include:

--- a/framework/installation/framework-releasepipeline.md
+++ b/framework/installation/framework-releasepipeline.md
@@ -11,8 +11,7 @@ Make sure the Project Collection Build Service has Administrator access to these
 > ![Library Security](../../images/ifa-library-security.png)
 
 ## YAML Pipeline
-Add the files and folders from [this](./pipelines) location to your DevOps repo. 
-This contains an example YAML pipeline to release the Invictus for Azure Framework, change the [framework.release.yaml](./pipelines/framework.release.yaml) file according to your needs, for example change the needed environments and change the name of the build pipeline trigger:
+Next step is to add a YAML pipeline to release the Invictus for Azure Framework. Change the [framework.release.yaml](./pipelines/framework.release.yaml) file according to your needs, for example change the needed environments and change the name of the build pipeline trigger:
 ``` yaml
 resources:
   pipelines:


### PR DESCRIPTION
Docusaurus cannot handle links to folders, and since working with versions, this is not easy to inject, we can directly use the build/release pipeline file as references.

This PR removes the folder references for an easier Docusaurus migration.