### PR TITLE
chore(docusaurus): prepare to hide subpages from docusaurus auto-gen sidebar

### DIFF
--- a/framework/components/transcoV2-Example.md
+++ b/framework/components/transcoV2-Example.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Full Transco V2 Example
 
 The following is a full example which demonstrates the usage of Transco V2.

--- a/framework/components/transcoV2-Matrix.md
+++ b/framework/components/transcoV2-Matrix.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Transco V2 - Matrix Functionality
 
 Matrix functionality has been rewritten in .NET 6.0 to modernize its capabilities. This functionality has now been included within the Transco V2 function, instead of its own standalone API.

--- a/framework/deprecated/matrix-basic.md
+++ b/framework/deprecated/matrix-basic.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Matrix - Basic Promotion
 
 > ## ⚠️ Attention

--- a/framework/deprecated/matrix-promote.md
+++ b/framework/deprecated/matrix-promote.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Matrix - Promotion
 
 > ## ⚠️ Attention

--- a/framework/deprecated/matrix.md
+++ b/framework/deprecated/matrix.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Matrix
 
 > ## ⚠️ Attention

--- a/framework/deprecated/pubsub.md
+++ b/framework/deprecated/pubsub.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Publish / Subscribe
 
 > ## ⚠️ Attention

--- a/framework/deprecated/transco-assemblies.md
+++ b/framework/deprecated/transco-assemblies.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Transco - Custom Assemblies
 
 > ## ⚠️ Attention

--- a/framework/deprecated/transco-extraction.md
+++ b/framework/deprecated/transco-extraction.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Transco - Extraction
 
 > ## ⚠️ Attention

--- a/framework/deprecated/transco.md
+++ b/framework/deprecated/transco.md
@@ -1,3 +1,7 @@
+---
+sidebar_class_name: hidden
+---
+
 # Transco
 
 > ## ⚠️ Attention

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -156,3 +156,7 @@ strong,
 nav.menu {
   padding: 1rem;
 }
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
Prepare to hide any sub-pages from the auto-generated Docusaurus sidebar, these pages are still URL-accessible, only not helpful to blow up the sidebar.