### PR TITLE
chore(pipelines): remove direct /pipelines folder ref link in dashboard

### DIFF
--- a/dashboard/installation/dashboard-buildpipeline.md
+++ b/dashboard/installation/dashboard-buildpipeline.md
@@ -18,8 +18,7 @@ Once you have obtained these values, create a variable group named `{prefix}.Inv
 - **Infra.Environment.ACRPassword**: value provided by Codit Software
 
 ## 3. Add YAML build pipeline
-Add the files and folders from [this](./pipelines) location to your DevOps repo. 
-This contains an example YAML pipelines to build the Invictus for Azure Dashboard, change the [dashboard.build.yaml](./pipelines/dashboard.build.yaml) file according to your needs, for example change the trigger path:
+Next step is to add a YAML pipeline to build the Invictus for Azure Dashboard. Change the [dashboard.build.yaml](./pipelines/dashboard.build.yaml) file according to your needs, for example change the trigger path:
 ``` yaml
   paths:
     include:


### PR DESCRIPTION
Remove direct folder reference on dashboard installation page as this is not supported by Docusaurus - and is also an unnecessary Markdown link as further down, the necessary file is linked, still.