### PR TITLE
chore(docusaurus): add local docusaurus search theme

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,6 +64,17 @@ module.exports = {
       additionalLanguages: ['csharp', 'diff', 'json', 'powershell', 'yaml'],
     },
   },
+  themes: [
+    [
+      require.resolve("@easyops-cn/docusaurus-search-local"),
+      /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
+      ({
+        // `hashed` is recommended as long-term-cache of index file is possible.
+        hashed: true,
+        docsRouteBasePath: '/'
+      }),
+    ]
+  ],
   presets: [
     [
       '@docusaurus/preset-classic',


### PR DESCRIPTION
Since we can't use the Algolia search as it is only for public sites, we have to use a local variant. Currently using the `easyops-cn` one, based on the Frontend's recommendations.

This PR adds this local search theme to the Docusaurus config in preparation for its activation.