### PR TITLE
chore(img): add image zoom capabilities

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,6 +43,9 @@ module.exports = {
         },
       ],
     },
+    zoom: {
+      // selector: '.img-zoom',
+    },
     footer: {
       style: 'dark',
       links: [
@@ -74,6 +77,9 @@ module.exports = {
         docsRouteBasePath: '/'
       }),
     ]
+  ],
+  plugins: [
+     'docusaurus-plugin-image-zoom'
   ],
   presets: [
     [

--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-    "name": "invictus-integration",
-    "version": "0.0.0",
-    "private": true,
-    "scripts": {
-      "docusaurus": "docusaurus",
-      "start": "docusaurus start",
-      "build": "docusaurus build --config ./docusaurus.config.js",
-      "swizzle": "docusaurus swizzle",
-      "deploy": "docusaurus deploy",
-      "clear": "docusaurus clear",
-      "serve": "docusaurus serve",
-      "write-translations": "docusaurus write-translations",
-      "write-heading-ids": "docusaurus write-heading-ids"
-    },
-    "dependencies": {
-      "@docusaurus/core": "^3.3.2",
-      "@docusaurus/preset-classic": "^3.3.2",
-      "@easyops-cn/docusaurus-search-local": "^0.49.2",
-      "@mdx-js/react": "^3.0.1",
-      "@svgr/webpack": "^8.1.0",
-      "clsx": "^2.1.1",
-      "file-loader": "^6.2.0",
-      "prism-react-renderer": "^2.3.1",
-      "react": "^18.3.1",
-      "react-dom": "^18.3.1",
-      "url-loader": "^4.1.1"
-    },
-    "browserslist": {
-      "production": [
-        ">0.5%",
-        "not dead",
-        "not op_mini all"
-      ],
-      "development": [
-        "last 1 chrome version",
-        "last 1 firefox version",
-        "last 1 safari version"
-      ]
-    }
+  "name": "invictus-integration",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "docusaurus": "docusaurus",
+    "start": "docusaurus start",
+    "build": "docusaurus build --config ./docusaurus.config.js",
+    "swizzle": "docusaurus swizzle",
+    "deploy": "docusaurus deploy",
+    "clear": "docusaurus clear",
+    "serve": "docusaurus serve",
+    "write-translations": "docusaurus write-translations",
+    "write-heading-ids": "docusaurus write-heading-ids"
+  },
+  "dependencies": {
+    "@docusaurus/core": "^3.3.2",
+    "@docusaurus/preset-classic": "^3.3.2",
+    "@easyops-cn/docusaurus-search-local": "^0.49.2",
+    "@mdx-js/react": "^3.0.1",
+    "@svgr/webpack": "^8.1.0",
+    "clsx": "^2.1.1",
+    "docusaurus-plugin-image-zoom": "^3.0.1",
+    "file-loader": "^6.2.0",
+    "prism-react-renderer": "^2.3.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "url-loader": "^4.1.1"
+  },
+  "browserslist": {
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
-  
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      docusaurus-plugin-image-zoom:
+        specifier: ^3.0.1
+        version: 3.0.1(@docusaurus/theme-classic@3.7.0(@types/react@19.1.5)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.99.9)
@@ -2304,6 +2307,11 @@ packages:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
 
+  docusaurus-plugin-image-zoom@3.0.1:
+    resolution: {integrity: sha512-mQrqA99VpoMQJNbi02qkWAMVNC4+kwc6zLLMNzraHAJlwn+HrlUmZSEDcTwgn+H4herYNxHKxveE2WsYy73eGw==}
+    peerDependencies:
+      '@docusaurus/theme-classic': '>=3.0.0'
+
   dom-converter@0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
 
@@ -3326,6 +3334,9 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  medium-zoom@1.1.0:
+    resolution: {integrity: sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -3739,6 +3750,14 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-root-regex@0.1.2:
+    resolution: {integrity: sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==}
+    engines: {node: '>=0.10.0'}
+
+  path-root@0.1.1:
+    resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
+    engines: {node: '>=0.10.0'}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -4415,6 +4434,10 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-package-path@4.0.3:
+    resolution: {integrity: sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==}
+    engines: {node: '>= 12'}
+
   resolve-pathname@3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
 
@@ -4913,6 +4936,10 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  validate-peer-dependencies@2.2.0:
+    resolution: {integrity: sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==}
+    engines: {node: '>= 12'}
 
   value-equal@1.0.1:
     resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
@@ -8338,6 +8365,12 @@ snapshots:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
+  docusaurus-plugin-image-zoom@3.0.1(@docusaurus/theme-classic@3.7.0(@types/react@19.1.5)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)):
+    dependencies:
+      '@docusaurus/theme-classic': 3.7.0(@types/react@19.1.5)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      medium-zoom: 1.1.0
+      validate-peer-dependencies: 2.2.0
+
   dom-converter@0.2.0:
     dependencies:
       utila: 0.4.0
@@ -9568,6 +9601,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  medium-zoom@1.1.0: {}
+
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.0.6
@@ -10117,6 +10152,12 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-root-regex@0.1.2: {}
+
+  path-root@0.1.1:
+    dependencies:
+      path-root-regex: 0.1.2
 
   path-to-regexp@0.1.12: {}
 
@@ -10934,6 +10975,10 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-package-path@4.0.3:
+    dependencies:
+      path-root: 0.1.1
+
   resolve-pathname@3.0.0: {}
 
   resolve@1.22.10:
@@ -11463,6 +11508,11 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
+
+  validate-peer-dependencies@2.2.0:
+    dependencies:
+      resolve-package-path: 4.0.3
+      semver: 7.7.2
 
   value-equal@1.0.1: {}
 

--- a/versioned_docs/version-v6.0.0/architecture-diagram.md
+++ b/versioned_docs/version-v6.0.0/architecture-diagram.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ## Invictus Dashboard Architecture
 
-![Architecture diagram](/images/InvictusV2Diagram_Dashboard.jpg "Invictus dashboard architecture diagram")
+<img src="/images/InvictusV2Diagram_Dashboard.jpg" alt="Invictus Dashboard architecture diagram" class="img-zoom" />
 
 ### Dashboard Components
 


### PR DESCRIPTION
This PR makes sure that viewers can click on images which causes them to zoom in on it. This functionality was previously built-in the Jekyll theme, but is not by default available in Docusaurus. Especially form full screenshots, this image zooming capabilities is helpful.