### PR TITLE
fix(operator.role): more concrete role definition on flow operations

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/security/03_roles.md
+++ b/versioned_docs/version-v6.0.0/dashboard/security/03_roles.md
@@ -32,4 +32,4 @@ Permissions in the Invictus Dashboard are separated into two categories: user ro
   | Operations on flows*     | 🔴       | 🟢        | 🟢             |
   | View folder/flows        | 🟢       | 🟢        | 🟢             |
 
-> \* *Flows can be resubmitted, resumed, and ignored via the Dashboard.*
+> \* *Flows originating from LogicApps workflows can be resubmitted, resumed, and ignored via the Dashboard.*


### PR DESCRIPTION
Only flows that originates from the LogicApps workflows can be resubmitted/resumed/ignored via the Dashboard. Flow traces that were imported any other way, can't.

This PR makes this more clear on the role pages.