### PR TITLE
chore(sidebar): make dashboard sidebar item collabsible

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/_category_.yml
+++ b/versioned_docs/version-v6.0.0/dashboard/_category_.yml
@@ -1,1 +1,3 @@
 position: 3
+collapsible: true
+collapsed: true


### PR DESCRIPTION
Makes the `Dashboard` sidebar item by default collasible + collapsed, so that people can choose which part of the Invictus documentation site they want to navigate to, without us forcing them in a direction (Dashboard or Framework).

Closes #348  