### PR TITLE
fix(framework): framework 'get sources' script link

### DIFF
--- a/versioned_docs/version-v6.0.0/framework/installation/framework-buildpipeline.md
+++ b/versioned_docs/version-v6.0.0/framework/installation/framework-buildpipeline.md
@@ -4,7 +4,7 @@ sidebar_class_name: hidden
 
 # Framework Build Pipeline
 
-The build pipeline uses a powershell script to pull the resources needed for the release. This script can be downloaded from [here](https://github.com/invictus-integration/docs-ifa/blob/master/dashboard/installation/scripts/Invictus-GetSources.ps1). Make sure to include it in your Git repository (e.g. in the deploy folder).
+The build pipeline uses a powershell script to pull the resources needed for the release. This script can be downloaded from [here](../../dashboard/installation/scripts/Invictus-GetSources.ps1). Make sure to include it in your Git repository (e.g. in the deploy folder).
 
 The pipeline will use variables stored in a variable group, so before creating the build pipeline open the DevOps Library page and create a new variable group.
 


### PR DESCRIPTION
During the migration of Docusaurus, some links were temporary hard-linked, but now that the migration is complete, these can now be relative links again.

One of those links is the 'get sources' script link on the Framework build page. This PR fixes that.
Closes #355  