### PR TITLE
fix(framework): use correct sub-references in pipeline templates

### DIFF
--- a/versioned_docs/version-v6.0.0/framework/installation/pipelines/framework.build.yaml
+++ b/versioned_docs/version-v6.0.0/framework/installation/pipelines/framework.build.yaml
@@ -35,7 +35,7 @@ stages:
       clean: true
       persistCredentials: true
 
-    - template: ./templates/build-steps.yml
+    - template: ./templates/build-steps.yaml
       parameters:
         type: 'framework'
         useBeta: '${{ parameters.useBeta }}'

--- a/versioned_docs/version-v6.0.0/framework/installation/pipelines/framework.release.yaml
+++ b/versioned_docs/version-v6.0.0/framework/installation/pipelines/framework.release.yaml
@@ -37,7 +37,7 @@ stages:
           steps:
           - download: '_build'
             displayName: Download Artifact
-          - template: ./templates/framework-release-steps.yml
+          - template: ./templates/framework-release-steps.yaml
             parameters:
               azureSubscription: 'NameOfYourServiceConnection'
               scriptPath: '$(Pipeline.Workspace)/_build/framework/Deploy.ps1'
@@ -58,7 +58,7 @@ stages:
           steps:
           - download: '_build'
             displayName: Download Artifact
-          - template: ./templates/framework-release-steps.yml
+          - template: ./templates/framework-release-steps.yaml
             parameters:
               azureSubscription: 'NameOfYourServiceConnection'
               scriptPath: '$(Pipeline.Workspace)/_build/framework/Deploy.ps1'
@@ -79,7 +79,7 @@ stages:
           steps:
           - download: '_build'
             displayName: Download Artifact
-          - template: ./templates/framework-release-steps.yml
+          - template: ./templates/framework-release-steps.yaml
             parameters:
               azureSubscription: 'NameOfYourServiceConnection'
               scriptPath: '$(Pipeline.Workspace)/_build/framework/Deploy.ps1'
@@ -100,7 +100,7 @@ stages:
           steps:
           - download: '_build'
             displayName: Download Artifact
-          - template: ./templates/framework-release-steps.yml
+          - template: ./templates/framework-release-steps.yaml
             parameters:
               azureSubscription: 'NameOfYourServiceConnection'
               scriptPath: '$(Pipeline.Workspace)/_build/framework/Deploy.ps1'


### PR DESCRIPTION
The Framework pipeline templates used an incorrect reference to a sub-build steps YAML template. This PR fixes these references.

Closes #357 