### PR TITLE
fix(var.group): correct naming convention in dashboard/framework variable groups

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/installation/pipelines/dashboard.release.yaml
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/pipelines/dashboard.release.yaml
@@ -26,8 +26,8 @@ stages:
   displayName: 'Deploy to Development'
   variables:
   - group: infra.dev
-  - group: invictus.dev
-  - group: invictus.installation
+  - group: prefix.invictus.dev
+  - group: prefix.invictus.installation
   jobs:
   - deployment: deploy_development
     displayName: 'Deploy to Development'
@@ -49,8 +49,8 @@ stages:
   dependsOn: deploy_dev
   variables:
   - group: infra.tst
-  - group: invictus.tst
-  - group: invictus.installation
+  - group: prefix.invictus.tst
+  - group: prefix.invictus.installation
   jobs:
   - deployment: deploy_tst
     displayName: 'Deploy to Test'
@@ -72,8 +72,8 @@ stages:
   dependsOn: deploy_tst
   variables:
   - group: infra.acc
-  - group: invictus.acc
-  - group: invictus.installation
+  - group: prefix.invictus.acc
+  - group: prefix.invictus.installation
   jobs:
   - deployment: deploy_acc
     displayName: 'Deploy to Acceptance'
@@ -95,8 +95,8 @@ stages:
   dependsOn: deploy_acc
   variables:
   - group: infra.prd
-  - group: invictus.prd
-  - group: invictus.installation
+  - group: prefix.invictus.prd
+  - group: prefix.invictus.installation
   jobs:
   - deployment: deploy_prd
     displayName: 'Deploy to Production'

--- a/versioned_docs/version-v6.0.0/framework/installation/pipelines/framework.release.yaml
+++ b/versioned_docs/version-v6.0.0/framework/installation/pipelines/framework.release.yaml
@@ -25,8 +25,9 @@ stages:
 - stage: deploy_dev
   displayName: 'Deploy to Development'
   variables:
-  - group: infra.tst
-  - group: invictus.tst
+  - group: infra.dev
+  - group: prefix.invictus.dev
+  - group: prefix.invictus.installation
   jobs:
   - deployment: deploy_development
     displayName: 'Deploy to Development'
@@ -47,7 +48,8 @@ stages:
   dependsOn: deploy_dev
   variables:
   - group: infra.tst
-  - group: invictus.tst
+  - group: prefix.invictus.tst
+  - group: prefix.invictus.installation
   jobs:
   - deployment: deploy_tst
     displayName: 'Deploy to Test'
@@ -68,7 +70,8 @@ stages:
   dependsOn: deploy_tst
   variables:
   - group: infra.acc
-  - group: invictus.acc
+  - group: prefix.invictus.acc
+  - group: prefix.invictus.installation
   jobs:
   - deployment: deploy_acc
     displayName: 'Deploy to Acceptance'
@@ -89,7 +92,8 @@ stages:
   dependsOn: deploy_acc
   variables:
   - group: infra.prd
-  - group: invictus.prd
+  - group: prefix.invictus.prd
+  - group: prefix.invictus.installation
   jobs:
   - deployment: deploy_prd
     displayName: 'Deploy to Production'


### PR DESCRIPTION
The feature documentation talks about `{prefix}.invictus.*` variable groups and ACR credentials being in the `{prefix}.invictus.installation` variable groups - which aren't always correctly defined in the provided YAML templates.

This PR fixes that.
Closes #358 