### PR TITLE
chore(bicep): use bicep instead of arm mentionings throughout

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/flows/01_add.md
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/01_add.md
@@ -55,7 +55,7 @@ This query type will filter logs on Azure Logs by the "InvictusImportJobFlowActi
 
 This will create a rule to run every 60 minutes, scans the logs for the last 60 minutes and if the returned value is less than the threshold, it means that the flow is inactive, thus triggers the alert on Azure.
 
-Please note that the importjob will not increment the activity for each message that is processed for a flow. This simply sends a single log per hour for each flow that is active, the count might be higher than one per hour due to scaling situations and multi-threaded scenarios. The logging frequency for the importjob can be increased by reducing the following value: **FlowActivityIntervalInMinutes**. This can be passed to the ARM template during deployment.
+Please note that the importjob will not increment the activity for each message that is processed for a flow. This simply sends a single log per hour for each flow that is active, the count might be higher than one per hour due to scaling situations and multi-threaded scenarios. The logging frequency for the importjob can be increased by reducing the following value: **FlowActivityIntervalInMinutes**. This can be passed to the Bicep template during deployment.
 
 `Invictus Error Check`
 

--- a/versioned_docs/version-v6.0.0/framework/deprecated/matrix.md
+++ b/versioned_docs/version-v6.0.0/framework/deprecated/matrix.md
@@ -15,11 +15,11 @@ sidebar_class_name: hidden
 
 ## Introduction
 
-The Matrix connector will be mainly used to promote properties from the content to the context using a promote config. The Matrix now also support JSON content and will promote any property to the context using JPath. All configs are to be stored in the storage container setup by the Resources ARM Template. The container which will house all configs is named: matrixconfigsstore.
+The Matrix connector will be mainly used to promote properties from the content to the context using a promote config. The Matrix now also support JSON content and will promote any property to the context using JPath. All configs are to be stored in the storage container setup by the Resources Bicep Template. The container which will house all configs is named: matrixconfigsstore.
 
 This container will be made available on Startup of the Matrix API. All Logic apps using this connector will have a dropdown available which loads all configs located in the storage blob container. A config blob is also cached for a configurable amount of time to reduce reads from blob since this will be triggered on each execution. This also increases speed and will only hinder the call which finds the cache expired.
 
-All technical logs are pushed to Application Insights, the setting for this can be found in the AppSettings of the API and can be switched to any other AppInsights. Authentication between the API and Key Vault will be handled using Managed Service Identity. This is all setup through the ARM template release.
+All technical logs are pushed to Application Insights, the setting for this can be found in the AppSettings of the API and can be switched to any other AppInsights. Authentication between the API and Key Vault will be handled using Managed Service Identity. This is all setup through the Bicep template release.
 
 For more information about the matrix functionality, follow the guides in the below pages:
 

--- a/versioned_docs/version-v6.0.0/framework/deprecated/pubsub.md
+++ b/versioned_docs/version-v6.0.0/framework/deprecated/pubsub.md
@@ -35,7 +35,7 @@ The PubSub connector will be mainly used to push messages to service bus using t
 * Timeout for Subscribe is set to 75 seconds by default
 * Blob Storage will only be used when message is greater than 256kb. This is configurable at API level.
 * Connectors can both be added using Http+Swagger and Azure App Services connector 
-* Subscribe should always use the LogicAppName as the subscription property. This can be done when using ARM deployments or typed manually 
+* Subscribe should always use the LogicAppName as the subscription property. This can be done when using Bicep deployments or typed manually 
 * Message time to live will be set to 3 months
 
 ### x-ms-workflow-run-id

--- a/versioned_docs/version-v6.0.0/framework/deprecated/transco.md
+++ b/versioned_docs/version-v6.0.0/framework/deprecated/transco.md
@@ -15,11 +15,11 @@ sidebar_class_name: hidden
 
 ## Introduction
 
-The Transco connector will be mainly used to promote properties from the database, it will use the content or the context to form the query and retrieve the data from the specified tables. The Transco now also support JSON content and will promote any key & value to the specified JPath. All configs are to be stored in the storage container setup by the Resources ARM Template. The container which will house all configs is named: `transcoconfigsstore`.
+The Transco connector will be mainly used to promote properties from the database, it will use the content or the context to form the query and retrieve the data from the specified tables. The Transco now also support JSON content and will promote any key & value to the specified JPath. All configs are to be stored in the storage container setup by the Resources Bicep Template. The container which will house all configs is named: `transcoconfigsstore`.
 
 This container will be made available on Startup of the Transco API. All Logic apps using this connector will have a dropdown available which loads all configs located in the storage blob container.
 
-All technical logs are pushed to Application Insights, the setting for this can be found in the AppSettings of the API and can be switched to any other AppInsights. Authentication between the API and Key Vault will be handled using Managed Service Identity. This is all setup through the ARM template release.
+All technical logs are pushed to Application Insights, the setting for this can be found in the AppSettings of the API and can be switched to any other AppInsights. Authentication between the API and Key Vault will be handled using Managed Service Identity. This is all setup through the Bicep template release.
 
 For more information about the matrix functionality, follow the guides in the below pages:
 


### PR DESCRIPTION
Some pages still mentioned 'ARM templates' while we already have moved towards Bicep a long time ago. This PR makes sure that we use 'Bicep' now.