### PR TITLE
fix(transco): use correct relative matrix path

### DIFF
--- a/versioned_docs/version-v6.0.0/framework/transcoV2.md
+++ b/versioned_docs/version-v6.0.0/framework/transcoV2.md
@@ -32,7 +32,7 @@ Transco V2 provides several endpoints:
 
 * `/api/MatrixBasicPromote`: does not accept any config. It accepts a simple list of parameters and promotes them to the Context.
 
-> 🔗 See [Transco V2 - Matrix Functionality](https://github.com/invictus-integration/docs-ifa/blob/master/framework/components/transcoV2-Matrix.md) for more details.
+> 🔗 See [Transco V2 - Matrix Functionality](./transcoV2-Matrix.md) for more details.
 
 ## Transco Config File
 A JSON Transco config file is required to specify details about the instruction which will be performed. Instructions are executed in the order in which they appear. The name of the config file should be specified in the request so that it can be retrieved from the storage account.


### PR DESCRIPTION
During the Docusaurus migration, some relative paths were changed to absolute paths to reduce the changes. Some of these paths aren't yet corrected.

This PR corrects the Matrix path on the Transco v2 page.