### PR TITLE
fix(release.pipeline): broken links on renamed .mdx release pipelines

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/installation/dashboard-migration.md
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/dashboard-migration.md
@@ -4,7 +4,7 @@ sidebar_class_name: hidden
 
 # Invictus Dashboard V2 Migration Guide
 
-Below is some useful information for when users are upgrading their Invictus installation from V1 to V2. To update your build and release pipelines, please refer to the [build pipeline](dashboard-buildpipeline.md) and [release pipeline](dashboard-releasepipeline.md) guides.
+Below is some useful information for when users are upgrading their Invictus installation from V1 to V2. To update your build and release pipelines, please refer to the [build pipeline](dashboard-buildpipeline.md) and [release pipeline](dashboard-releasepipeline.mdx) guides.
 
 ## Build pipeline
 The storage container for Dashboard V2 is `dashboard-v2`, so update the `StorageContainerName` parameter you use in the build pipeline.

--- a/versioned_docs/version-v6.0.0/dashboard/installation/dashboard-migration.md
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/dashboard-migration.md
@@ -36,7 +36,7 @@ Invictus V2 includes functionality to migrate the SQL data from your previous in
 
 ### Data Migration Release Pipeline Changes
 
-The data migration process forms part of the release pipeline. Please refer to [release pipeline](dashboard-releasepipeline.md) for more information. The deploy script parameter `PerformSqlDataMigration` must be set to `1`. The deploy script also accepts a few optional parameters to be able to connect to your SQL database:
+The data migration process forms part of the release pipeline. Please refer to [release pipeline](dashboard-releasepipeline.mdx) for more information. The deploy script parameter `PerformSqlDataMigration` must be set to `1`. The deploy script also accepts a few optional parameters to be able to connect to your SQL database:
 
 - -sqlToMigrateServerName : Server name hosting the SQL DB you wish to migrate. Defaults to `invictus-{ResourcePrefix}-sqlsvr`
 - -sqlToMigrateDBName : Name of the SQL DB you wish to migrate. Defaults to `coditcip`

--- a/versioned_docs/version-v6.0.0/dashboard/installation/dashboard-vnet.md
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/dashboard-vnet.md
@@ -46,9 +46,9 @@ If the Invictus resources and the VNET are on different resource groups, then th
 
 ## Release Pipeline Changes
 
-The release pipeline remains the same as explained [here](dashboard-releasepipeline.md), but with a set of VNET specific parameters. The `enableVnetSupport` parameter must be set to `$true` to enable the functionality. The name of the resource group containing the VNET, as well as the VNET name itself must be passed to the `vnetResourceGroupName` and `vnetName` parameters. An array containing the names of the desired subnets must be passed to the `keyVaultSubnets`, `storageAccountSubnets`, `serviceBusSubnets`, `cosmosDbSubnets`, `eventHubSubnets` parameters. You will also need to pass the subnet names to connect the Container App Environment and private endpoints. These parameters are `containerAppEnvironmentSubnetName`, `privateEndpointSubnetName`.
+The release pipeline remains the same as explained [here](dashboard-releasepipeline.mdx), but with a set of VNET specific parameters. The `enableVnetSupport` parameter must be set to `$true` to enable the functionality. The name of the resource group containing the VNET, as well as the VNET name itself must be passed to the `vnetResourceGroupName` and `vnetName` parameters. An array containing the names of the desired subnets must be passed to the `keyVaultSubnets`, `storageAccountSubnets`, `serviceBusSubnets`, `cosmosDbSubnets`, `eventHubSubnets` parameters. You will also need to pass the subnet names to connect the Container App Environment and private endpoints. These parameters are `containerAppEnvironmentSubnetName`, `privateEndpointSubnetName`.
 
-A full list of VNET parameters can be found [here](dashboard-releasepipeline.md).
+A full list of VNET parameters can be found [here](dashboard-releasepipeline.mdx).
 
 ### Full Deploy Script Parameters Example
 

--- a/versioned_docs/version-v6.0.0/dashboard/installation/index.md
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/index.md
@@ -14,7 +14,7 @@ Follow [this guide](./dashboard-buildpipeline.md) to setup your build in Azure D
 
 ## 3. Release Pipeline
 
-Follow [this guide](./dashboard-releasepipeline.md) to setup your release in Azure DevOps.
+Follow [this guide](./dashboard-releasepipeline.mdx) to setup your release in Azure DevOps.
 
 ## 4. Setup
 

--- a/versioned_docs/version-v6.0.0/framework/installation/framework-buildpipeline.md
+++ b/versioned_docs/version-v6.0.0/framework/installation/framework-buildpipeline.md
@@ -28,4 +28,4 @@ Next step is to add YAML pipelines to build the Invictus for Azure Framework. Ch
     - /src/customer.azure.invictus
 ```
 
-Afterwards add the [framework.build.yaml](./pipelines/framework.build.yaml) in your DevOps environment as a pipeline, once you've saved the build pipeline you can create the [release pipeline](framework-releasepipeline.md)
+Afterwards add the [framework.build.yaml](./pipelines/framework.build.yaml) in your DevOps environment as a pipeline, once you've saved the build pipeline you can create the [release pipeline](framework-releasepipeline.mdx)

--- a/versioned_docs/version-v6.0.0/framework/installation/framework-migration.md
+++ b/versioned_docs/version-v6.0.0/framework/installation/framework-migration.md
@@ -10,11 +10,11 @@ This document will guide you through the process of migrating the build & releas
 
 Nothing changes for the build pipeline.
 
-The difference lies in the artifacts that the build produces, everything needed for the release is now included in the build (powershells, resources, etc..), which greatly simplyfies the release pipeline.
+The difference lies in the artifacts that the build produces, everything needed for the release is now included in the build (scripts, resources, etc..), which greatly simplifies the release pipeline.
 
 ## Release Pipeline
 
-The task group is now replaced by a single Azure Powershell task included in the build artifacts. Please refer to the [release pipeline](framework-releasepipeline.md) for more information.
+The task group is now replaced by a single Azure Powershell task included in the build artifacts. Please refer to the [release pipeline](framework-releasepipeline.mdx) for more information.
 
 The following task group parameters should be used as the powershell's arguments:
 

--- a/versioned_docs/version-v6.0.0/framework/installation/index.md
+++ b/versioned_docs/version-v6.0.0/framework/installation/index.md
@@ -14,13 +14,13 @@ Follow [this guide](framework-buildpipeline.md) to setup your build in Azure Dev
 
 ## 3. Release Pipeline
 
-Follow [this guide](framework-releasepipeline.md) to setup your release in Azure DevOps.
+Follow [this guide](framework-releasepipeline.mdx) to setup your release in Azure DevOps.
 
 ## 4. VNET Support
 
 Enabling Azure Virtual Network support for the Invictus Framework is an identical process as for the Invictus Dashboard. Therefore you can follow the same guide found [here](../../dashboard/installation/dashboard-vnet.md).
 
-A full list of VNET specific parameters which can be passed to Framework release pipeline can be found [here](./framework-releasepipeline.md).
+A full list of VNET specific parameters which can be passed to Framework release pipeline can be found [here](./framework-releasepipeline.mdx).
 
 ## Migrating pipelines
 Migrating the build & release pipelines to the new procedure associated with version 2.4.0 or greater can be found [here](./framework-migration.md)


### PR DESCRIPTION
The PR #354 made sure that the release pipelines are more descriptive, but failed to rename all link references to it. It seems that this renaming did not let the CI pipeline fail, but it did fail the CD pipeline.
This PR follows-up this file renaming, which fixes the Docusaurus CD build.