### PR TITLE
fix(transco.v2): broken links after .mdx conversion

### DIFF
--- a/versioned_docs/version-v6.0.0/framework/deprecated/transco-assemblies.md
+++ b/versioned_docs/version-v6.0.0/framework/deprecated/transco-assemblies.md
@@ -9,7 +9,7 @@ sidebar_class_name: hidden
 > 
 > Maximum supported .NET version is .NET Framework 4.7.1
 > 
-> For the supported version, please see [Transco V2](../transcoV2.md)
+> For the supported version, please see [Transco V2](../transcoV2.mdx)
 
 ## Introduction
 

--- a/versioned_docs/version-v6.0.0/framework/deprecated/transco.md
+++ b/versioned_docs/version-v6.0.0/framework/deprecated/transco.md
@@ -9,9 +9,9 @@ sidebar_class_name: hidden
 > 
 > Maximum supported .NET version is .NET Framework 4.7.1
 > 
-> For the supported version, please see [Transco V2](../transcoV2.md)
+> For the supported version, please see [Transco V2](../transcoV2.mdx)
 >
-> For the migration guide from v1 to v2 see [here](../transcoV2.md#Migrating-Transco-v1-to-v2)
+> For the migration guide from v1 to v2 see [here](../transcoV2.mdx#migrating-Transco-v1-to-v2)
 
 ## Introduction
 


### PR DESCRIPTION
> 👉 Follow-up of #373 

For some strange reason, the broken links were not showing during PR CI builds, but only during halting the deployment. This PR fixes the broken links to the converted Transco v2 `.mdx` file.