### PR TITLE
docs(framework.scaling): add `concurrentRequests` scaling parameter to framework scaling

### DIFF
--- a/versioned_docs/version-v6.0.0/framework/installation/framework-releasepipeline.mdx
+++ b/versioned_docs/version-v6.0.0/framework/installation/framework-releasepipeline.mdx
@@ -333,12 +333,13 @@ Each of the above parameters accepts an object:
 }
 ```
 
-| Parameter value    | Description                                                                                            |
-| -------------------| ------------------------------------------------------------------------------------------------------ |
-| `scaleMinReplicas` | The lowest number of replicas the Container App will scale in to.                                      |
-| `scaleMaxReplicas` | The highest number of replicas the Container App will scale out to.                                    |
-| `cpuResources`     | The amount of cpu resources to dedicate for the container resource. [See here for allowed values](https://learn.microsoft.com/en-us/azure/container-apps/containers#allocations).       |
-| `memoryResources`  | The amount of memory resources to dedicate for the container resource. [See here for allowed values](https://learn.microsoft.com/en-us/azure/container-apps/containers#allocations).    |
+| Parameter value      | Default  | Description                                                                                            |
+| -------------------- | :------: | ------------------------------------------------------------------------------------------------------ |
+| `scaleMinReplicas`   | `0`      | The lowest number of replicas the Container App will scale in to.                                      |
+| `scaleMaxReplicas`   | `1`      | The highest number of replicas the Container App will scale out to.                                    |
+| `cpuResources`       | `0.5`    | The amount of cpu resources to dedicate for the container resource. [See here for allowed values](https://learn.microsoft.com/en-us/azure/container-apps/containers#allocations).       |
+| `memoryResources`    | `1.0Gi`  | The amount of memory resources to dedicate for the container resource. [See here for allowed values](https://learn.microsoft.com/en-us/azure/container-apps/containers#allocations).    |
+| `concurrentRequests` | `10`     | When the number of HTTP requests exceeds this value, then another replica is added. Replicas continue to add to the pool up to the maxReplicas amount. [See here fore allowed values](https://learn.microsoft.com/en-us/azure/container-apps/scale-app?pivots=container-apps-bicep). |
 </details>
 
 </ToggleProvider>


### PR DESCRIPTION
Starting from v6, we have an additional `concurrentRequests` scaling parameter available for the Framework components. This PR adds this parameter, plus showcases the default values for the others as well.