### PR TITLE
fix(link): use correct links for framework docs

### DIFF
--- a/versioned_docs/version-v6.0.0/architecture-diagram.md
+++ b/versioned_docs/version-v6.0.0/architecture-diagram.md
@@ -36,7 +36,7 @@ Within the client integrations (here always Azure Logic Apps), several common in
 * [**PubSub v2:**](./framework/pubsubV2.md) uses Azure Service Bus as a message broker to publish/subscribe on messages across Azure Logic Apps. 
 * [**TimeSequencer:**](./framework/timesequencer.md) control the order in which Azure Logic App workflows can run based on a custom timestamp.
 * [**Sequence Controller:**](./framework/sequencecontroller.md) control the order in which Azure Logic App workflow can run based on a custom sequence order.
-* [**XML/JSON Convertor:**](./framework/xmljsonconverter.md) convert XML-JSON based on a custom XSLT transformation.
+* [**XML/JSON Convertor:**](./framework/xmljsonconverter.mdx) convert XML-JSON based on a custom XSLT transformation.
 * [**XSD Validator:**](./framework/xsd-validator.md) validate XML based on a custom XSD schema.
 * [**Regex Translator**](./framework/regextranslation.md) translate user content based on custom regular expression patterns.
 * [**Transco v2:**](./framework/transcoV2.mdx) promote properties in an user content based on database records.

--- a/versioned_docs/version-v6.0.0/framework/index.md
+++ b/versioned_docs/version-v6.0.0/framework/index.md
@@ -6,7 +6,7 @@ When implementing the Framework in your integration you will achieve a high leve
 
 ## Installing the Framework
 
-Follow [this guide](installation/index.md) to setup your build and release pipelines in DevOps.
+Follow [this guide](installation/index.mdx) to setup your build and release pipelines in DevOps.
 
 ## Release Notes
 


### PR DESCRIPTION
Due to late merges with the main branch and parallel PR's, some broken links were only discovered when trying to release the new version from the main branch -- instead of being halted at PR-time.

This PR fixes the broken links in the Framework docs related to the XML/JSON Converter and the installation page.