### PR TITLE
fix(breadcrumb): use md logo link in breadcrumb

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -249,10 +249,14 @@ html[data-theme='dark'] .vnet table, html[data-theme='dark'] .vnet td {
   margin: 5px 5px 20px 5px;
 }
 
-.custom-breadcrumb img {
-  display: inline;
+.custom-breadcrumb p img {
+  margin: auto;
   padding: 0;
   width: 80%;
+}
+
+.custom-breadcrumb p {
+  margin:0;
 }
 
 .breadcrumb-item {
@@ -282,4 +286,5 @@ html[data-theme='dark'] .vnet table, html[data-theme='dark'] .vnet td {
 
 .no-padding {
   padding: 0;
+  margin: 0;
 }

--- a/versioned_docs/version-v6.0.0/dashboard/flows/01_add.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/01_add.mdx
@@ -7,7 +7,7 @@ Each [folder](./index.md#organizing-flows-in-folders) can hold one or more 'flow
 ## Add/Edit a flow
 <nav class="custom-breadcrumb">
   <span class="breadcrumb-item no-padding">
-    <img src="/img/favicon.ico" alt="logo" />
+    ![logo](/img/favicon.ico)
   </span>
   <span>›</span>
   <span class="breadcrumb-item">Your Flows</span>


### PR DESCRIPTION
Use the correct link in the breakcrumb for the Invictus logo, as this was not correctly rendered remotely.