### PR TITLE
chore(flow): use badges to mark certain flow sections 'only for...' or 'requires...'

### DIFF
--- a/src/components/OnlyAdminsBadge.js
+++ b/src/components/OnlyAdminsBadge.js
@@ -1,8 +1,19 @@
 import { useState } from 'react'
 
 export function OnlyAdminsBadge() {
-  const [visible, setVisible] = useState(false);
+  return OnlyBadge({ title: "Only Admins", tooltip: "This section describes functionality that's only available for users with a System Admin role." });
+}
 
+export function OnlyOperatorsBadge() {
+  return OnlyBadge({ title: "Requires Operator", tooltip: "This section describes functionality that requires at least Operator permissions on the flow" });
+}
+
+export function OnlyFolderAdminsBadge() {
+  return OnlyBadge({ title: "Only Admins", tooltip: "This section describes functionality that's only available for users with a Folder or System Admin role."});
+}
+
+export function OnlyBadge({title, tooltip}) {
+  const [visible, setVisible] = useState(false);
   return (
     <span
       style={{ position: 'relative', display: 'inline-block', marginLeft: '8px', textTransform: 'none', fontWeight: 'bold' }}
@@ -22,7 +33,7 @@ export function OnlyAdminsBadge() {
           userSelect: 'none',
         }}
       >
-        Only Admins
+        {title}
       </span>
       {visible && (
         <span
@@ -43,7 +54,7 @@ export function OnlyAdminsBadge() {
             pointerEvents: 'none',
           }}
         >
-          This section describes functionality that's only available for users with a System Admin role.
+          {tooltip}
           <span
             style={{
               position: 'absolute',

--- a/versioned_docs/version-v6.0.0/dashboard/flows/01_add.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/01_add.mdx
@@ -1,10 +1,15 @@
+---
+sidebar_label: Add new flows
+---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { OnlyFolderAdminsBadge } from '@site/src/components/OnlyAdminsBadge';
 
 # Add new flows
 Each [folder](./index.md#organizing-flows-in-folders) can hold one or more 'flows'. These are message chains, an aggregation of all the messages that can be linked to the same incoming message. Flows are the functional representation of the message with an optional context property name and / or optional context property value.
 
-## Add/Edit a flow
+## Add/Edit a flow <OnlyFolderAdminsBadge/>
 <nav class="custom-breadcrumb">
   <span class="breadcrumb-item no-padding">
     <img src="/img/favicon.ico" alt="logo" />
@@ -27,7 +32,7 @@ Each [folder](./index.md#organizing-flows-in-folders) can hold one or more 'flow
 | <span class="no-wrap"><span class="flow-add-number">4</span> **Business Properties**</span> | no | Additional properties to describe the flow. These are only here to provide metadata and are not used in the flow tracing. |
 | <span class="no-wrap"><span class="flow-add-number">5</span> **Advanced Settings**</span> | no | <ul><li>*Connected Dashboard:* if the flow has multiple Dashboards and it needs to connect to another Dashboard then this needs to be checked.  For this setting to apply, the Connected Dashboard needs to be enabled by your Admin through the settings page of the Dashboard in order to switch on this feature.</li><li>*Show milestone and event text:* Checking this option will enable the flow milestone and event text data to be displayed.</li><li>*Custom resubmit/resume URLs:* Check these options and provide the necessary URLs to use [your own resume and resubmit logic](./04_import-flow-traces/import-flows-via-la.mdx).</li></ul> |
 
-## Permissions
+## Permissions <OnlyFolderAdminsBadge/>
 To allow only certain users/groups to access the flows, you can assign permissions to the folder where the flow is located ([available roles](../security/03_roles.md)). System admins are automatically assigned to every folder available.
 
 <nav class="custom-breadcrumb">
@@ -61,7 +66,7 @@ Choose the desired non-admin user from the first drop down menu. Then, choose th
 </TabItem>
 </Tabs>
 
-## Alerting
+## Alerting <OnlyFolderAdminsBadge/>
 :::warning
 To manage alerts within Flows, make sure the [necessary **role assignments** are set](../installation/03_give_la_access.md) in your Invictus installation.
 :::

--- a/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import-flows-via-la.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import-flows-via-la.mdx
@@ -1,5 +1,6 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { OnlyFolderAdminsBadge, OnlyOperatorsBadge } from '@site/src/components/OnlyAdminsBadge'
 
 # Import flow traces via Azure Logic App workflows
 Invictus is fully supported to import flows from Azure Logic Apps. It allows to keep track of the **execution tree** of the ran workflows, plus with **tracked properties** you can trace specific data for your needs besides the general **diagnostic settings**.
@@ -50,7 +51,7 @@ Alternatively, you can update your Bicep template to include them, using [AVM](h
 ```
 </details>
 
-## Map Dashboard flows to Azure Logic App workflow runs
+## Map Dashboard flows to Azure Logic App workflow runs <OnlyFolderAdminsBadge/>
 Make sure that any [tracked property](#tracked-properties-of-workflows) in the workflow matches these values in the [flow created via the Dashboard](../01_add.mdx):
 * WorkflowName (if present)
 * Domain (if present)
@@ -116,7 +117,7 @@ If the corresponding logic app has resulted in an error, the error information c
 For any additional details or insights, the user can also navigate directly to the Azure Portal.
 </details>
 
-## Workflow operations via Dashboard
+## Workflow operations via Dashboard <OnlyOperatorsBadge/>
 :::warning
 Requires the `x-iv-parent-workflow-run-id` to be set on the workflows to run properly.
 Flows linked to Azure Logic Apps workflows can be resubmitted and resumed via the Dashboard both separately (via the flow actions button) and in batch (via selecting multiple flows).


### PR DESCRIPTION
Use badges besides titles of sections to mark certain sections of flow-related functionality with 'Only for System/Folder admins' or 'Requires at least Operator'. This includes role management throughout the feature documentation and helps with permission assignment and understanding difference in accessibility.