### PR TITLE
chore(flowtrace.la): use walkthrough for import flow traces via la

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import-flows-via-la.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import-flows-via-la.mdx
@@ -1,121 +1,125 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { Walkthrough, Task } from '@site/src/components/Walkthrough';
 import { OnlyFolderAdminsBadge, OnlyOperatorsBadge } from '@site/src/components/OnlyAdminsBadge'
 
 # Import flow traces via Azure Logic App workflows
 Invictus is fully supported to import flows from Azure Logic Apps. It allows to keep track of the **execution tree** of the ran workflows, plus with **tracked properties** you can trace specific data for your needs besides the general **diagnostic settings**.
 
-## Enable workflow diagnostics
-For the Invictus Dashboard to know if messages went through your Logic App workflow correctly or not, diagnostic settings need to be configured on all Logic Apps that you want to include. These settings should stream their diagnostic traces to the Invictus EventHubs resource:
+<Walkthrough>
+  <Task title="Enable workflow diagnostics">
+    For the Invictus Dashboard to know if messages went through your Logic App workflow correctly or not, diagnostic settings need to be configured on all Logic Apps that you want to include. These settings should stream their diagnostic traces to the Invictus EventHubs resource:
 
-* `EventHubsNamespace`: `invictus-{env}-we-sft-evnm`
-* `EventHubsName`:
-  * `invictus-{env}-we-sft-evhb` (Logic Apps Consumption) 
-  * `invictus-{env}-we-sft-evhb-v2` (Logic Apps Standard)
+    * `EventHubsNamespace`: `invictus-{env}-we-sft-evnm`
+    * `EventHubsName`:
+      * `invictus-{env}-we-sft-evhb` (Logic Apps Consumption) 
+      * `invictus-{env}-we-sft-evhb-v2` (Logic Apps Standard)
 
-:::warning
-Make sure that the `WorkflowRuntime` is **✅ checked**, but the `AllMetrics` is **❌ unchecked**. Otherwise you will send far too much events to the EventHubs.
-:::
+    :::warning
+    Make sure that the `WorkflowRuntime` is **✅ checked**, but the `AllMetrics` is **❌ unchecked**. Otherwise you will send far too much events to the EventHubs.
+    :::
 
-![diagnostics](/images/ladiagnostics.png)
+    ![diagnostics](/images/ladiagnostics.png)
 
-> 🔗 See [Microsoft's documentation](https://learn.microsoft.com/en-us/azure/logic-apps/monitor-workflows-collect-diagnostic-data?tabs=consumption) on how this can be configured manually.
+    > 🔗 See [Microsoft's documentation](https://learn.microsoft.com/en-us/azure/logic-apps/monitor-workflows-collect-diagnostic-data?tabs=consumption) on how this can be configured manually.
 
-<details>
-<summary>**Bicep AVM alternative example**</summary>
+    <details>
+    <summary>**Bicep AVM alternative example**</summary>
 
-Alternatively, you can update your Bicep template to include them, using [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/logic/workflow#parameter-diagnosticsettings):
+    Alternatively, you can update your Bicep template to include them, using [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/logic/workflow#parameter-diagnosticsettings):
 
-```bicep
-{
-  ...
-  diagnosticSettings: [
-      {
-        name: settingName
-        eventHubName: eventHubName
-        eventHubAuthorizationRuleResourceId: resourceId(
-          resourceGroupName,
-          'Microsoft.EventHub/namespaces/authorizationRules',
-          eventHubNamespace,
-          'RootManageSharedAccessKey'
-        )
-        logCategoriesAndGroups: [
+    ```bicep
+    {
+      ...
+      diagnosticSettings: [
           {
-            category: 'WorkflowRuntime'
-            enabled: true
+            name: settingName
+            eventHubName: eventHubName
+            eventHubAuthorizationRuleResourceId: resourceId(
+              resourceGroupName,
+              'Microsoft.EventHub/namespaces/authorizationRules',
+              eventHubNamespace,
+              'RootManageSharedAccessKey'
+            )
+            logCategoriesAndGroups: [
+              {
+                category: 'WorkflowRuntime'
+                enabled: true
+              }
+            ]
           }
         ]
-      }
-    ]
-}
-```
-</details>
+    }
+    ```
+    </details>
+  </Task>
 
-## Map Dashboard flows to Azure Logic App workflow runs <OnlyFolderAdminsBadge/>
-Make sure that any [tracked property](#tracked-properties-of-workflows) in the workflow matches these values in the [flow created via the Dashboard](../01_add.mdx):
-* WorkflowName (if present)
-* Domain (if present)
-* Service (if present)
-* Action (if present)
-* Version (if present)
+  <Task title="Map Dashboard flows to Azure Logic App workflow runs">
+  <OnlyFolderAdminsBadge/>
+    
+    Make sure that any [tracked property](#tracked-properties-of-workflows) in the workflow matches these values in the [flow created via the Dashboard](../01_add.mdx):
+    * WorkflowName (if present)
+    * Domain (if present)
+    * Service (if present)
+    * Action (if present)
+    * Version (if present)
+  </Task>
 
-## Execution tree of sequentially ran workflows
-When expanding the flows in the Dashboard you should be able to see what workflows have been executed sequentially to process the message.
+  <Task title="Link child workflow to parent Azure Logic App workflow">
+    When expanding the flows in the Dashboard you should be able to see what workflows have been executed sequentially to process the message.
 
-![execution tree](/images/v2_events1.png)
+    ![execution tree](/images/v2_events1.png)
 
-To link one workflow with another the `x-iv-parent-workflow-run-id` [tracked property](#tracked-properties-of-workflows) needs to be set when designing the Logic App.
+    To link one workflow with another the `x-iv-parent-workflow-run-id` [tracked property](#tracked-properties-of-workflows) needs to be set when designing the Logic App.
 
-The value for the property needs to be the `WorkFlowRunId` that you wish to link the Azure Logic App to. The below logic app is using the following tracked property to promote the `WorkFlowRunId` of **LogicAppChain-A** as a tracked property in **LogicAppChain-B**.
+    The value for the property needs to be the `WorkFlowRunId` that you wish to link the Azure Logic App to. The below logic app is using the following tracked property to promote the `WorkFlowRunId` of **LogicAppChain-A** as a tracked property in **LogicAppChain-B**.
 
-| Key                           | Value                                                      |
-| ----------------------------- | ---------------------------------------------------------- |
-| `x-iv-parent-workflow-run-id` | `@{triggerOutputs()?['headers']?['x-ms-workflow-run-id']}` |
+    | Key                           | Value                                                      |
+    | ----------------------------- | ---------------------------------------------------------- |
+    | `x-iv-parent-workflow-run-id` | `@{triggerOutputs()?['headers']?['x-ms-workflow-run-id']}` |
 
-![execution tree](/images/import-executiontree.png)
+    ![execution tree](/images/import-executiontree.png)
 
-In the example above, the **x-iv-parent-workflow-run-id** was set in **LogicAppChain-B** linking it with **LogicAppChain-A**. **LogicAppChain-C** was not linked to **B** or **A** thus is not considered part of the chain.
+    In the example above, the **x-iv-parent-workflow-run-id** was set in **LogicAppChain-B** linking it with **LogicAppChain-A**. **LogicAppChain-C** was not linked to **B** or **A** thus is not considered part of the chain.
 
-:::warning
-The **ClientTrackingId** is the identifier used to link transactional messages together, this ID is by default generated for every run in Azure Logic Apps, but can also be manually set by the developer. Since async flows might change their ClientTrackingId due to routing, the ClientTrackingId will need to be reset in the Azure Logic App as soon as possible.
-:::
+    :::warning
+    The **ClientTrackingId** is the identifier used to link transactional messages together, this ID is by default generated for every run in Azure Logic Apps, but can also be manually set by the developer. Since async flows might change their ClientTrackingId due to routing, the ClientTrackingId will need to be reset in the Azure Logic App as soon as possible.
+    :::
+  </Task>
 
-## Tracked properties of workflows
-The `Milestone` and `EventText` are properties set and displayed by default. For the `EventText`, if the value re-appears in several workflows, instead of overwriting/updating its value, all data is appended as a single value, separated by comma.
+  <Task title="Add tracked properties to Azure Logic App workflows">
+    The `Milestone` and `EventText` are properties set and displayed by default, if present. For the `EventText`, if the value re-appears in several workflows, instead of overwriting/updating its value, all data is appended as a single value, separated by comma.
 
-![execution tree](/images/v2_events2.png)
+    ![execution tree](/images/v2_events2.png)
+  </Task>
 
-<details>
-<summary>**Azure Logic App input/outputs**</summary>
+  <Task title="Add Azure Logic App workflow results">
+    > 🛡️ For this feature to function properly some role assignments need to be set in your Invictus installation. Please see [Access Control Rights](../../installation/03_give_la_access.md) for more info.
 
-> 🛡️ For this feature to function properly some role assignments need to be set in your Invictus installation. Please see [Access Control Rights](../../installation/03_give_la_access.md) for more info.
+    The message content view allows the user to track the outputs and inputs of an action. The links are the friendly names set in the tracked properties of the "tracked" action. The links will point to their respectively input/output content. These are visible per Azure Logic App in the workflow events table. 
 
-The message content view allows the user to track the outputs and inputs of an action. The links are the friendly names set in the tracked properties of the "tracked" action. The links will point to their respectively input/output content. These are visible per Azure Logic App in the workflow events table. 
+    To track the input/output of an action in an Azure Logic App the below tracked properties have to be set in an action.
 
-To track the input/output of an action in an Azure Logic App the below tracked properties have to be set in an action.
+    | Property Name                    | Sample Value | Description |
+    | -------------------------------- | ------------ | ----------- |
+    | `x-iv-messagecontent-input-name` | `ActionInput`  | This is the friendly name displayed in the ClickThrough/ExecutionTree, the value can be anything you like. The value has to be a single word |
+    | `x-iv-messagecontent-input-content-type` | `application/json` |This should have the same content type as the data type when opening the input link for an action|
+    | `x-iv-messagecontent-output-name` | `ActionOutput` | This is the friendly name displayed in the ClickThrough/ExecutionTree, the value can be anything you like. The value has to be a single word|
+    | `x-iv-messagecontent-output-content-type` | `application/json` | This should have the same content type as the data type when opening the input link for an action |
 
-| Property Name                    | Sample Value | Description |
-| -------------------------------- | ------------ | ----------- |
-| `x-iv-messagecontent-input-name` | `ActionInput`  | This is the friendly name displayed in the ClickThrough/ExecutionTree, the value can be anything you like. The value has to be a single word |
-| `x-iv-messagecontent-input-content-type` | `application/json` |This should have the same content type as the data type when opening the input link for an action|
-| `x-iv-messagecontent-output-name` | `ActionOutput` | This is the friendly name displayed in the ClickThrough/ExecutionTree, the value can be anything you like. The value has to be a single word|
-| `x-iv-messagecontent-output-content-type` | `application/json` | This should have the same content type as the data type when opening the input link for an action |
+    :::warning
+    The inputs and outputs content views can be set up independently or together. The only requirement is that if the `-name` is present then the `-content-type` has to be also present for the desired output.
+    :::
 
-:::warning
-The inputs and outputs content views can be set up independently or together. The only requirement is that if the `-name` is present then the `-content-type` has to be also present for the desired output.
-:::
+    **Errors on Azure Logic App level**
 
-</details>
+    If the corresponding logic app has resulted in an error, the error information can be seen in the within the "Logic App Details" modal.
 
-<details>
-<summary>**Errors on Azure Logic App level**</summary>
+    ![execution tree](/images/v2_events5.png)
 
-If the corresponding logic app has resulted in an error, the error information can be seen in the within the "Logic App Details" modal.
-
-![execution tree](/images/v2_events5.png)
-
-For any additional details or insights, the user can also navigate directly to the Azure Portal.
-</details>
+    For any additional details or insights, the user can also navigate directly to the Azure Portal.
+  </Task>
+</Walkthrough>
 
 ## Workflow operations via Dashboard <OnlyOperatorsBadge/>
 :::warning


### PR DESCRIPTION
There are several steps that consumers need to follow for them to successfully import their flow traces into the Dashboard. The non-numbered sections were not that clear that this is part of a broader walkthrough.

This PR separates the 'importing' from the 'usage' section, by making sure that we provide a walkthrough for the 'importing' and leaving the 'usage' section directly visible.