### PR TITLE
fix(flow): logo in breadcrumbs

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/flows/01_add.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/01_add.mdx
@@ -37,7 +37,7 @@ To allow only certain users/groups to access the flows, you can assign permissio
 
 <nav class="custom-breadcrumb">
   <span class="breadcrumb-item no-padding">
-    <img src="/img/favicon.ico" alt="logo" />
+    ![logo](/img/favicon.ico)
   </span>
   <span>›</span>
   <span class="breadcrumb-item">Your Flows</span>
@@ -73,7 +73,7 @@ To manage alerts within Flows, make sure the [necessary **role assignments** are
 
 <nav class="custom-breadcrumb">
   <span class="breadcrumb-item no-padding">
-    <img src="/img/favicon.ico" alt="logo" />
+    ![logo](/img/favicon.ico)
   </span>
   <span>›</span>
   <span class="breadcrumb-item">Your Flows</span>


### PR DESCRIPTION
Some breadcrumbs were still using the raw HTML tags to reference the Invictus logo, which did not render correctly. This PR fixes this by using the markdown syntax instead.