### PR TITLE
fix(deploy): remove '/docs-ifa' route from base URL

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Install and Build
         run: |
           sed -i \
-            -e "s|baseUrl: '.*'|baseUrl: '/docs-ifa/'|" \
             -e 's/includeCurrentVersion: true/includeCurrentVersion: false/' \
             docusaurus.config.js
           cat docusaurus.config.js   


### PR DESCRIPTION
Remove `/docs-ifa` from `baseUrl:` in the Docusaurus config when deploying from the main branch.
This fixes the recent change on the URL redirection.