### PR TITLE
fix(deploy): add missing 'CNAME' file due to redirect

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.invictus-integration.com


### PR DESCRIPTION
Because GitHub Pages uses a custom domain, this domain needs to be configured via a CNAME on the Docusaurus as well. To do that, one needs a CNAME file in the `/static` folder, as this gets copied to the root of the site upon deployment. This PR adds that file; without it, the GitHub Pages deployment still points to the old URL and results in 404 NotFound when accessing the custom domain.