### PR TITLE
chore(scaling): use '0' as scale min replicas in dashboard

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
@@ -852,16 +852,16 @@ Container Apps have the ability to scale down to zero replicas. This is a great 
 
 | Parameter                      | Required | Available options as JSON object (with defaults) |
 | ------------------------------ | :------: | ----------------- |
-| `dashboardScaling`             | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`1`)</li><li>`scaleMaxReplicas` (`5`)</li><li>`concurrentRequests` (`100`)</li></ul> |
-| `dashboardGatewayScaling`      | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`1`)</li><li>`scaleMaxReplicas` (`5`)</li><li>`concurrentRequests` (`100`)</li></ul> |
-| `cacheImportJobScaling`        | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`1`)</li><li>`scaleMaxReplicas` (`20`)</li><li>`messageCount` (`1000`)</li></ul> |
-| `dbImportJobScaling`           | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`1`)</li><li>`scaleMaxReplicas` (`20`)</li><li>`unprocessedEventThreshold` (`2000`)</li></ul> |
-| `datafactoryReceiverScaling`   | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`1`)</li><li>`scaleMaxReplicas` (`10`)</li></ul> |
-| `flowhandlerScaling`           | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`1`)</li><li>`scaleMaxReplicas` (`1`)</li></ul> |
+| `dashboardScaling`             | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`5`)</li><li>`concurrentRequests` (`100`)</li></ul> |
+| `dashboardGatewayScaling`      | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`5`)</li><li>`concurrentRequests` (`100`)</li></ul> |
+| `cacheImportJobScaling`        | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`20`)</li><li>`messageCount` (`1000`)</li></ul> |
+| `dbImportJobScaling`           | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`20`)</li><li>`unprocessedEventThreshold` (`2000`)</li></ul> |
+| `datafactoryReceiverScaling`   | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`10`)</li></ul> |
+| `flowhandlerScaling`           | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`1`)</li></ul> |
 | `genericReceiverScaling`       | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`10`)</li></ul> |
 | `httpReceiverScaling`          | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`10`)</li></ul> |
 | `importJobScaling`             | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`1`)</li><li>`scaleMaxReplicas` (`20`)</li><li>`unprocessedEventThreshold` (`2000`)</li></ul> |
-| `storeImportJobScaling`        | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`1`)</li><li>`scaleMaxReplicas` (`30`)</li><li>`unprocessedEventThreshold` (`2000`)</li></ul> |
+| `storeImportJobScaling`        | No       | <ul><li>`cpuResources` (`0.5`)</li><li>`memoryResources` (`1.0Gi`)</li><li>`scaleMinReplicas` (`0`)</li><li>`scaleMaxReplicas` (`30`)</li><li>`unprocessedEventThreshold` (`2000`)</li></ul> |
 
 Each of the above parameters accepts an object with their options when passing as Bicep parameter, example:
 ```shell


### PR DESCRIPTION
To streamline scaling across Invictus, we should use the same scale min replicas as the Framework components in the Dashboard. This PR sets all the Dashboard scale min replicas to zero. (https://dev.azure.com/codit/Invictus/_git/dashboard/pullrequest/9433).