### PR TITLE
chore(scaling): warn for non-zero scale min replicas

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
@@ -878,6 +878,10 @@ Each of the above parameters accepts an object with their options when passing a
 | `unprocessedEventThreshold` | `int`    | The target number of unprocessed events per worker for Event Hub-triggered functions. [Microsoft docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.webjobs.eventhubs.eventhuboptions.targetunprocessedeventthreshold) |
 | `concurrentRequests`        | `int`    | When the number of HTTP requests exceeds this value, then another replica is added. Replicas continue to add to the pool up to the maxReplicas amount. [See here fore allowed values](https://learn.microsoft.com/en-us/azure/container-apps/scale-app?pivots=container-apps-bicep). |
 
+:::warning[careful with `scaleMinReplicas`]
+When the `scaleMinReplicas` is set to a greater number than zero, then the amount of replicas and costs can increase rapidly when older replicas are not disposed of in time. Use with care.
+:::
+
 </details>
 </ToggleProvider>
 

--- a/versioned_docs/version-v6.0.0/framework/installation/index.mdx
+++ b/versioned_docs/version-v6.0.0/framework/installation/index.mdx
@@ -640,6 +640,10 @@ Each of the above parameters accepts an object:
 | `scaleMaxReplicas`          | `int`    | `1`    | The highest number of replicas the Container App will scale out to.                                    |
 | `concurrentRequests`        | `int`    | `10`    | When the number of HTTP requests exceeds this value, then another replica is added. Replicas continue to add to the pool up to the maxReplicas amount. [See here fore allowed values](https://learn.microsoft.com/en-us/azure/container-apps/scale-app?pivots=container-apps-bicep). |
 
+:::warning[careful with `scaleMinReplicas`]
+When the `scaleMinReplicas` is set to a greater number than zero, then the amount of replicas and costs can increase rapidly when older replicas are not disposed of in time. Use with care.
+:::
+
 </details>
 
 </ToggleProvider>


### PR DESCRIPTION
Warn end-users for the use of non-zero `scaleMinReplicas` as this can drive the costs up, if older replicas are not disposed of in time.

Relates to https://dev.azure.com/codit/Invictus/_git/dashboard/pullrequest/9433