### PR TITLE
chore(installation): add missing invictusUserManagedIdentityName bicep param to install guides

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
@@ -478,6 +478,7 @@ Resource-independent parameters that affect all resources in the deployed resour
 | `devOpsObjectId`                   |   Yes    |                                  | Object ID of the service principal that's connected to the DevOps service connection, which will get the necessary role definitions to interact with Invictus' deployed resources (i.e. Key vault, Container registry) ([Azure CLI task]) |
 | `containerAppsEnvironmentLocation` |    No    | `resourceGroup().location`       | Location of the ACA environment and Container Apps.                                                                                                                                                                                       |
 | `containerAppsEnvironmentName`     |    No    | `invictus-${resourcePrefix}-cae` | The name of the [Container App environment](https://learn.microsoft.com/en-us/azure/container-apps/environment).                                                                                                                          |
+| `invictusUserManagedIdentityName`  |    No    | `invictus-user-managed-identity` | The name of the Azure user managed identity that has access to all the deployed Invictus Container App components.                                                                                                                        |
 
 <ToggleSection>
 | VNET Parameter                          | Required | Default                                | Description                                                                               |

--- a/versioned_docs/version-v6.0.0/framework/installation/index.mdx
+++ b/versioned_docs/version-v6.0.0/framework/installation/index.mdx
@@ -416,6 +416,7 @@ Resource-independent parameters that affect all resources in the deployed resour
 | `devOpsObjectId` | Yes      |         | The object-id associated with the service principal of the enterprise application that's connected to the service connection on DevOps |
 | `containerAppsEnvironmentLocation` | No | `resourceGroup().location` | Location of the ACA environment and Container Apps. |
 | `containerAppsEnvironmentName` | No | `invictus-${resourcePrefix}-cae` | The name of the [Container App environment](https://learn.microsoft.com/en-us/azure/container-apps/environment). |
+| `invictusUserManagedIdentityName` | No | `invictus-user-managed-identity` | The name of the Azure user managed identity that has access to all the deployed Invictus Container App components. |
 
 <ToggleSection>
 | VNET Parameter                         | Required | Default | Description          |


### PR DESCRIPTION
The `invictusUserManagedIdentityName` Bicep parameter was not yet documented in the installation guides. This PR adds it for both the Dashboard and Framework.

Relates to #374 