### PR TITLE
chore(installation): hide prev/next paginages on installation pages

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
@@ -1,5 +1,7 @@
 ---
 hide_table_of_contents: true
+pagination_prev: null
+pagination_next: null
 ---
 
 import { ToggleSwitch, ToggleSection, ToggleRow, ToggleProvider } from '@site/src/components/VnetToggleSwitch';

--- a/versioned_docs/version-v6.0.0/framework/installation/index.mdx
+++ b/versioned_docs/version-v6.0.0/framework/installation/index.mdx
@@ -1,5 +1,7 @@
 ---
 hide_table_of_contents: true
+pagination_prev: null
+pagination_next: null
 ---
 
 import { ToggleSwitch, ToggleSection, ToggleRow, ToggleProvider } from '@site/src/components/VnetToggleSwitch';


### PR DESCRIPTION
Since the installation pages are having their own pagination, we don't want to include the auto-generated Docusaurus prev/next page buttons at the bottom.