### PR TITLE
chore(vale): ignore common invictus wording

### DIFF
--- a/vale.ini
+++ b/vale.ini
@@ -7,4 +7,4 @@ Vocab = Invictus
 [*.md]
 BasedOnStyles = Vale, write-good
 
-TokenIgnores = methodology, [Vv]alidate, Multiple Revision mode, monitor(ing)?, pagination_prev, pagination_prev
+TokenIgnores = methodology, [Vv]alidate, Multiple Revision mode, monitor(ing)?, pagination_prev, pagination_next


### PR DESCRIPTION
Ignore certain common technical, Azure and Invictus related wordings in the Vale initialization file. 