### PR TITLE
docs: remove edit URL from docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,8 +92,6 @@ module.exports = {
           routeBasePath: '/',
           path: 'preview',
           sidebarCollapsible: false,
-          // Please change this to your repo.
-          editUrl: 'https://github.com/invictus-integration/docs-ifa/edit/master/docs',
           includeCurrentVersion: true,
           admonitions: {
             keywords: ['praise'],


### PR DESCRIPTION
Removed the edit URL for the documentation repository, as we shouldn't expose 'edit' rights to external users.