### PR TITLE
chore(exn.hanlder): temp remove ai services bicep params

### DIFF
--- a/src/data/framework.v6.bicep.parameters.json
+++ b/src/data/framework.v6.bicep.parameters.json
@@ -756,14 +756,6 @@
     ]
   },
   {
-    "name": "aiServicesSubnets",
-    "description": "A list of subnet names to form the network rules for the Azure AI Foundry resource, useful for VNET deployments.",
-    "tags": [
-      "networking",
-      "vnet"
-    ]
-  },
-  {
     "name": "containerAppEnvironmentSubnets",
     "description": "A list of subnet names to form the network rules of all the Azure Container App resources, useful for VNET deployments.",
     "tags": [
@@ -815,14 +807,6 @@
     "tags": [
       "networking",
       "vnet"
-    ]
-  },
-  {
-    "name": "useAIExceptionHandlerInterpreter",
-    "description": "Feature flag to control whether the Framework deploys with Azure AI Foundry services, useful for the Exception Handler component.",
-    "default": "false",
-    "tags": [
-      "comp:exception-handler"
     ]
   }
 ]


### PR DESCRIPTION
Removes the already documented AI services Bicep parameters for the Exception Handler component so we can first decide on the course of action with the 'add-ons' system.