### PR TITLE
chore(gh.issue): correct issue templates w/ new backlog format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug report.yml
+++ b/.github/ISSUE_TEMPLATE/bug report.yml
@@ -1,23 +1,20 @@
 name: 🐞 Bug report
-description: Report a bug in the Invictus project.
-title: "🐞 [Bug]: "
+description: Report a bug in the Invictus product.
+title: '🐞 [Bug]: '
 labels:
   - bug
+  - triage
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for your contribution to the Invictus project!
-  - type: dropdown
-    id: invictus-category
+        Thanks for your contribution to the Invictus product!
+  - type: input
+    id: invictus-version
     attributes:
-      label: Category
-      description: In what area of the project does this bug belong?
-      multiple: true
-      options:
-        - Dashboard visualization
-        - Framework components
-        - Documentation
+      label: Version
+      description: In what version of the product did this bug occur?
+      placeholder: Ex. 6.0.0
   - type: textarea
     id: expected-behavior
     attributes:
@@ -39,12 +36,6 @@ body:
         1. Provide the Transco with a configuration
         2. Reference the configuration in the request
         3. Notice how the response is incorrect
-  - type: input
-    id: invictus-version
-    attributes:
-      label: Invictus version
-      description: The version of the Invictus project where the bug occurred.
-      placeholder: Ex. 1.0.0
   - type: textarea
     id: context
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: ❔ Ask a question about Invictus
+    url: https://github.com/invictus-integration/docs-ifa/discussions/new?category=q-a
+    about: Ask a question about using Invictus, or anything related to the product.
   - name: 💬 Discuss something Invictus
     url: https://github.com/invictus-integration/docs-ifa/discussions/new
     about: Ask a question, praise, speculate ideas or request support for using Invictus.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,23 +1,20 @@
-name: 💪 Enhancement request
-description: Suggest an improvement to the Invictus project.
-title: "💪 [Enhancement]: "
+name: 💪 Enhance request
+description: Suggest an improvement to the Invictus product.
+title: '💪 [Enhance]: '
 labels:
   - enhancement
+  - triage
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for you contribution to the Invictus project!
-  - type: dropdown
-    id: invictus-category
+        Thanks for your contribution to the Invictus product!
+  - type: input
+    id: invictus-version
     attributes:
-      label: Category
-      description: In what area of the project does this enhancement belong?
-      multiple: true
-      options:
-        - Dashboard visualization
-        - Framework components
-        - Documentation
+      label: Version
+      description: What version of the product are you running?
+      placeholder: Ex. 6.0.0
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yml
@@ -1,22 +1,20 @@
 name: ✨ New feature request
-description: Suggest a new feature to the Invictus project.
-title: "✨ [New]: "
+description: Suggest a new feature to the Invictus product.
+title: '✨ [New]: '
 labels:
   - new feature
+  - triage
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for you contribution to the Invictus project!
-  - type: dropdown
-    id: invictus-category
+        Thanks for your contribution to the Invictus product!
+  - type: input
+    id: invictus-version
     attributes:
-      label: Category
-      description: In what area of the project does this new feature belong?
-      multiple: true
-      options:
-        - Dashboard visualization
-        - Framework components
+      label: Version
+      description: What version of the product are you running?
+      placeholder: Ex. 6.0.0
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
Streamline the issue templates with a version input instead of unnecessary dropdown to streamline Invictus as a single product, plus adding by-default 'triage' for better overview of tracked issues on our own backlog what which ones aren't.

