### PR TITLE
chore(v6): add minor version wildcard to showcase the minor-version cross-wide setup

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ const config = {
           lastVersion: 'v6.0.0',
           versions: {
             'v6.0.0': {
-              label: 'v6',
+              label: 'v6.x',
               badge: false,
             }
           }


### PR DESCRIPTION
Make sure that the version dropdown on the site shows the `v6.x` label to showcase that the documentation is based on major version differences and minor versions are all documented in the same format.

