### PR TITLE
fix(v4.v5.migration): fix sidebar label with v4.x to v.5

### DIFF
--- a/versioned_docs/version-v6.0.0/support/migrate-v4-to-v5.md
+++ b/versioned_docs/version-v6.0.0/support/migrate-v4-to-v5.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Migrate from v5.x to v6
+sidebar_label: Migrate from v4.x to v5
 pagination_prev: null
 pagination_next: null
 ---


### PR DESCRIPTION
The label of the v4.x to v5 was incorrect set. This PR fixes that.