### PR TITLE
chore(titles): remove badge code from dashboard page titles

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/flows/01_add.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/01_add.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Add new flows
+title: Add new flows
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-v6.0.0/dashboard/security/04_auditing.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/security/04_auditing.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_label: View audits 
+sidebar_label: View audits
+title: View audits
 ---
 
 import { OnlyAdminsBadge } from '@site/src/components/OnlyAdminsBadge';


### PR DESCRIPTION
Some page titles where exposing the badge code in their tab title. This PR overrides the page title with pure text.

