### PR TITLE
chore(titles): remove html code from framework page titles

### DIFF
--- a/versioned_docs/version-v6.0.0/framework/exceptionHandler.mdx
+++ b/versioned_docs/version-v6.0.0/framework/exceptionHandler.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Exception Handler
+title: Exception Handler
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-v6.0.0/framework/pubsubV2.mdx
+++ b/versioned_docs/version-v6.0.0/framework/pubsubV2.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: PubSub
+title: PubSub
 ---
 
 import ParameterTable from "@site/src/components/ParameterTable";

--- a/versioned_docs/version-v6.0.0/framework/regextranslation.mdx
+++ b/versioned_docs/version-v6.0.0/framework/regextranslation.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Regex Translator
+title: Regex Translator
 ---
 
 import ParameterTable from "@site/src/components/ParameterTable";

--- a/versioned_docs/version-v6.0.0/framework/sequencecontroller.mdx
+++ b/versioned_docs/version-v6.0.0/framework/sequencecontroller.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Sequence Controller
+title: Sequence Controller
 ---
 
 import ParameterTable from "@site/src/components/ParameterTable";

--- a/versioned_docs/version-v6.0.0/framework/timesequencer.mdx
+++ b/versioned_docs/version-v6.0.0/framework/timesequencer.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Time Sequencer
+title: Time Sequencer
 ---
 
 import ParameterTable from "@site/src/components/ParameterTable";

--- a/versioned_docs/version-v6.0.0/framework/transcoV2.mdx
+++ b/versioned_docs/version-v6.0.0/framework/transcoV2.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Transco
+title: Transco
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-v6.0.0/framework/xmljsonconverter.mdx
+++ b/versioned_docs/version-v6.0.0/framework/xmljsonconverter.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: XML/JSON Converter
+title: XML/JSON Converter
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-v6.0.0/framework/xsd-validator.mdx
+++ b/versioned_docs/version-v6.0.0/framework/xsd-validator.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: XSD Validator
+title: XSD Validator
 ---
 
 import ParameterTable from "@site/src/components/ParameterTable";


### PR DESCRIPTION
Removes the raw HTML code from the tab titles of the Framework components, using the same sidebar label instead of the title of the page.

