### PR TITLE
docs(dashboard.scaling): add warning on heavy load on import traces in dashboard

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/installation/index.mdx
@@ -194,6 +194,10 @@ The identity running the Bicep deployment (the service principal used by your Az
 
 </details>
 
+:::warning[heavy load deployment]
+Carefully consider the <a href="./?tags=scaling#bicep-template-parameters">BICEP scaling parameters</a> on Azure Container Apps and Cosmos DB for heavy load scenarios that require many diagnostic trace imports. 
+:::
+
 ### Mandatory Parameters
 
 [publish and download build artifacts]: https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml


### PR DESCRIPTION
Add warning on the Dashboard installation page to be careful of heavy load deployments, where the BICEP scaling parameters can help with many diagnostic trace imports.

