### PR TITLE
chore(vale): add common Google style for technical documentation

### DIFF
--- a/vale.ini
+++ b/vale.ini
@@ -1,4 +1,4 @@
-Packages = write-good, Microsoft, proselint, alex
+Packages = write-good, Microsoft, Google, proselint, alex
 
 StylesPath = .github/styles
 MinAlertLevel = warning
@@ -9,7 +9,7 @@ WordTemplate = \b(?:%s)\b
 mdx = md
 
 [*.{md,mdx}]
-BasedOnStyles = Vale, write-good, Microsoft, proselint, alex
+BasedOnStyles = Vale, write-good, Microsoft, Google, proselint, alex
 BlockIgnores = (<(img|br|Tabs|Redirect|a|MvnBadge|embed|Csrf)\s[^>]+>+?), \
 (?s) *(import[^\n]+;), \
 (?s) *(\-\-\-.*?\-\-\-), \
@@ -18,6 +18,7 @@ TokenIgnores = (<(img|br|Tabs|Redirect|a|MvnBadge|embed|Csrf)\s[^\n]+>+?), \
 methodology, [Vv]alidate, Multiple Revision mode, monitor(ing)?, pagination_prev, pagination_next, Microsoft Entra ID, backend, execute, [Ee]xecution, [Ff]ailed, failure, special
 CommentDelimiters = {/*, */}
 proselint.Diacritical = ignore
+Google.Headings = NO
 
 [versioned_docs/version-v6.0.0/framework/deprecated/*.{md,mdx}]
 BasedOnStyles =


### PR DESCRIPTION
Adding Google style will help with certain wording for tenses and acronyms for current and future docs.