### PR TITLE
chore(css): streamline common colors with new dark mode theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -84,6 +84,7 @@ html[data-theme='dark'] {
   --ifm-toc-border-color: black;
   --ifm-breadcrumb-color-active: var(--ifm-link-color);
   --ifm-dropdown-background-color: var(--ifm-color-gray-800);
+  --ifm-table-stripe-background: #1A202C
 }
 
 html[data-theme='dark'] .footer--dark {
@@ -125,6 +126,10 @@ html[data-theme='dark'] .alert--praise {
 
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: var(--ifm-color-gray-800);
+}
+
+code {
+  background-color: var(--ifm-color-gray-100);
 }
 
 html[data-theme='dark'] code {


### PR DESCRIPTION
Some common places like stripped table rows and code blocks in Docusaurus admonitions were showing background colors mismatching the new chosen dark theme with the Invictus Dashboard background color. This PR fixes that.

