### PR TITLE
chore(admonition): override default admonitions to better control streamlined style

### DIFF
--- a/src/theme/Admonition/Type/danger.module.css
+++ b/src/theme/Admonition/Type/danger.module.css
@@ -1,0 +1,18 @@
+.admonition {
+  --ifm-alert-background-color: #fff1f2;
+  --ifm-alert-background-color-highlight: #ffe4e6;
+  --ifm-alert-foreground-color: #881337;
+  --ifm-alert-border-color: #f43f5e;
+}
+
+html[data-theme='dark'] .admonition {
+  --ifm-alert-background-color: #2d0a12;
+  --ifm-alert-background-color-highlight: #3f1020;
+  --ifm-alert-foreground-color: #fda4af;
+  --ifm-alert-border-color: #e11d48;
+}
+
+.admonition svg {
+  height: 1.2em;
+  vertical-align: 0;
+}

--- a/src/theme/Admonition/Type/danger.tsx
+++ b/src/theme/Admonition/Type/danger.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import type { Props } from '@theme/Admonition/Type/Danger';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFire } from '@fortawesome/free-solid-svg-icons';
+import styles from './danger.module.css';
+
+const infimaClassName = 'alert alert--danger';
+
+const defaultProps = {
+  icon: <FontAwesomeIcon icon={faFire} />,
+  title: (
+    <Translate
+      id="theme.admonition.danger"
+      description="The default label used for the Danger admonition (:::danger)">
+      danger
+    </Translate>
+  ),
+};
+
+export default function AdmonitionTypeDanger(props: Props): JSX.Element {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, styles.admonition, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/info.module.css
+++ b/src/theme/Admonition/Type/info.module.css
@@ -1,0 +1,18 @@
+.admonition {
+  --ifm-alert-background-color: #f0f9fb;
+  --ifm-alert-background-color-highlight: #d9f1f5;
+  --ifm-alert-foreground-color: #014550;
+  --ifm-alert-border-color: var(--ifm-color-primary);
+}
+
+html[data-theme='dark'] .admonition {
+  --ifm-alert-background-color: var(--ifm-color-gray-800);
+  --ifm-alert-background-color-highlight: #103038;
+  --ifm-alert-foreground-color: #a8d8de;
+  --ifm-alert-border-color: var(--ifm-color-primary);
+}
+
+.admonition svg {
+  height: 1.2em;
+  vertical-align: 0;
+}

--- a/src/theme/Admonition/Type/info.tsx
+++ b/src/theme/Admonition/Type/info.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import type { Props } from '@theme/Admonition/Type/Info';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
+import styles from './info.module.css';
+
+const infimaClassName = 'alert alert--info';
+
+const defaultProps = {
+  icon: <FontAwesomeIcon icon={faCircleInfo} />,
+  title: (
+    <Translate
+      id="theme.admonition.info"
+      description="The default label used for the Info admonition (:::info)">
+      info
+    </Translate>
+  ),
+};
+
+export default function AdmonitionTypeInfo(props: Props): JSX.Element {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, styles.admonition, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/note.module.css
+++ b/src/theme/Admonition/Type/note.module.css
@@ -1,0 +1,23 @@
+.admonition {
+  --ifm-alert-background-color: #ffffff;
+  --ifm-alert-background-color-highlight: #d9f1f5;
+  --ifm-alert-foreground-color: var(--ifm-gray-900);
+  --ifm-alert-border-color: var(--ifm-color-gray-300);
+}
+
+html[data-theme='dark'] .admonition {
+  --ifm-alert-background-color: var(--ifm-color-gray-800);
+  --ifm-alert-background-color-highlight: var(--ifm-color-gray-800);
+  --ifm-alert-foreground-color: var(--ifm-gray-900);
+  --ifm-alert-border-color: var(--ifm-color-gray-300);
+}
+
+.admonition svg {
+  height: 1.2em;
+  vertical-align: 0;
+}
+
+.admonition code {
+  color: var(--ifm-alert-foreground-color);
+  background: transparent;
+}

--- a/src/theme/Admonition/Type/note.tsx
+++ b/src/theme/Admonition/Type/note.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import type { Props } from '@theme/Admonition/Type/Note';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faNoteSticky } from '@fortawesome/free-solid-svg-icons';
+import styles from './note.module.css';
+
+const infimaClassName = 'alert alert--note';
+
+const defaultProps = {
+  icon: <FontAwesomeIcon icon={faNoteSticky} />,
+  title: (
+    <Translate
+      id="theme.admonition.note"
+      description="The default label used for the Note admonition (:::note)">
+      note
+    </Translate>
+  ),
+};
+
+export default function AdmonitionTypeNote(props: Props): JSX.Element {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, styles.admonition, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/tip.module.css
+++ b/src/theme/Admonition/Type/tip.module.css
@@ -1,0 +1,18 @@
+.admonition {
+  --ifm-alert-background-color: #ecfdf5;
+  --ifm-alert-background-color-highlight: #d1fae5;
+  --ifm-alert-foreground-color: #065f46;
+  --ifm-alert-border-color: #065f46;
+}
+
+html[data-theme='dark'] .admonition {
+  --ifm-alert-background-color: #0d2e20;
+  --ifm-alert-background-color-highlight: #14432e;
+  --ifm-alert-foreground-color: #6ee7b7;
+  --ifm-alert-border-color: #059669;
+}
+
+.admonition svg {
+  height: 1.2em;
+  vertical-align: 0;
+}

--- a/src/theme/Admonition/Type/tip.tsx
+++ b/src/theme/Admonition/Type/tip.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import type { Props } from '@theme/Admonition/Type/Tip';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faLightbulb } from '@fortawesome/free-solid-svg-icons';
+import styles from './tip.module.css';
+
+const infimaClassName = 'alert alert--success';
+
+const defaultProps = {
+  icon: <FontAwesomeIcon icon={faLightbulb} />,
+  title: (
+    <Translate
+      id="theme.admonition.tip"
+      description="The default label used for the Tip admonition (:::tip)">
+      tip
+    </Translate>
+  ),
+};
+
+export default function AdmonitionTypeTip(props: Props): JSX.Element {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, styles.admonition, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/warning.module.css
+++ b/src/theme/Admonition/Type/warning.module.css
@@ -1,0 +1,18 @@
+.admonition {
+  --ifm-alert-background-color: #fff8ec;
+  --ifm-alert-background-color-highlight: #ffecc8;
+  --ifm-alert-foreground-color: #7a3800;
+  --ifm-alert-border-color: #b55d00;
+}
+
+html[data-theme='dark'] .admonition {
+  --ifm-alert-background-color: #2e1c00;
+  --ifm-alert-background-color-highlight: #3f2800;
+  --ifm-alert-foreground-color: #ffd08a;
+  --ifm-alert-border-color: #b55d00;
+}
+
+.admonition svg {
+  height: 1.2em;
+  vertical-align: 0;
+}

--- a/src/theme/Admonition/Type/warning.tsx
+++ b/src/theme/Admonition/Type/warning.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import type { Props } from '@theme/Admonition/Type/Warning';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import styles from './warning.module.css';
+
+const infimaClassName = 'alert alert--warning';
+
+const defaultProps = {
+  icon: <FontAwesomeIcon icon={faTriangleExclamation} />,
+  title: (
+    <Translate
+      id="theme.admonition.warning"
+      description="The default label used for the Warning admonition (:::warning)">
+      warning
+    </Translate>
+  ),
+};
+
+export default function AdmonitionTypeWarning(props: Props): JSX.Element {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, styles.admonition, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Types.js
+++ b/src/theme/Admonition/Types.js
@@ -1,10 +1,20 @@
 import React from 'react';
 import DefaultAdmonitionTypes from '@theme-original/Admonition/Types';
 import PraiseAdmonition from './Type/praise';
+import TipAdmonition from './Type/tip';
+import InfoAdmonition from './Type/info';
+import WarningAdmonition from './Type/warning';
+import DangerAdmonition from './Type/danger';
+import NoteAdmonition from './Type/note';
 
 const AdmonitionTypes = {
   ...DefaultAdmonitionTypes,
-  'praise': PraiseAdmonition
+  'praise': PraiseAdmonition,
+  'tip': TipAdmonition,
+  'info': InfoAdmonition,
+  'warning': WarningAdmonition,
+  'danger': DangerAdmonition,
+  'note': NoteAdmonition
 };
 
 export default AdmonitionTypes;


### PR DESCRIPTION
When we override Docusaurus' default admonitions, we can better control the style and coloring with the other colorful components on the documentation pages.

