### PR TITLE
chore(faq): use background color for faq answer pane

### DIFF
--- a/src/components/resultRow.module.css
+++ b/src/components/resultRow.module.css
@@ -390,7 +390,6 @@
 .answerPanel {
   padding: 12px 16px 12px calc(16px + 3px + 12px + 32px + 12px);
   border-bottom: 1px solid var(--ifm-color-secondary-lighter);
-  background: var(--ifm-background-surface-color);
   line-height: 1.6;
   font-size: 0.875rem;
 }


### PR DESCRIPTION
We should use the same background color for the answer pane to boost readability.