### PR TITLE
chore(sidebar): reorder flow trace import pages in sidebar

### DIFF
--- a/versioned_sidebars/version-v6.0.0-sidebars.json
+++ b/versioned_sidebars/version-v6.0.0-sidebars.json
@@ -57,16 +57,16 @@
         {
           "type": "category",
           "label": "Import flow traces",
-           "link": {
+          "link": {
             "type": "doc",
             "id": "dashboard/flows/import-flow-traces/index"
           },
           "items": [
+            "dashboard/flows/import-flow-traces/import-flows-via-la",
             "dashboard/flows/import-flow-traces/import flow-via-fa",
-            "dashboard/flows/import-flow-traces/import-flow-prog-via-eh",
-            "dashboard/flows/import-flow-traces/import-flow-prog-via-http",
             "dashboard/flows/import-flow-traces/import-flow-via-df",
-            "dashboard/flows/import-flow-traces/import-flows-via-la"
+            "dashboard/flows/import-flow-traces/import-flow-prog-via-eh",
+            "dashboard/flows/import-flow-traces/import-flow-prog-via-http"
           ]
         }
       ]


### PR DESCRIPTION
Reorder the flow trace importing pages so that Logic Apps is the first and the programmatically/advanced ones are last.

