### PR TITLE
chore(color): use same green coloring as new custom admonitions in badges throughout

### DIFF
--- a/src/components/OnlyAdminsBadge.js
+++ b/src/components/OnlyAdminsBadge.js
@@ -29,7 +29,7 @@ export function NewSinceBadge({ version }) {
   return Badge({
     title: `New since ${version}`,
     tooltip: `Feature included since **Invictus ${version}**.`,
-    backgroundColor: '#008800',
+    backgroundColor: '#059669',
     color: 'white',
   });
 }

--- a/src/components/resultRow.module.css
+++ b/src/components/resultRow.module.css
@@ -289,7 +289,7 @@
 
 .badgeRequired   { background-color: #b10006; }
 .badgeDeprecated { background-color: #b55d00; }
-.badgeSince      { background-color: #008800; }
+.badgeSince      { background-color: #059669; }
 .badgeDefault    { background-color: var(--ifm-color-emphasis-200); color: var(--ifm-font-color-base); }
 
 .versionBadge {


### PR DESCRIPTION
Use the same color green in the badges throughout as the one used in the custom admonitions. In a further improvement, we can centralize these coloring in CSS variables.

