### PR TITLE
fix(function.app): use dedicated tab title for function apps page to prevent to include badge

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import flow-via-fa.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import flow-via-fa.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Import via Function Apps
+title: Import flow traces via Azure Function App logs
 ---
 
 import { NewSinceBadge } from '@site/src/components/OnlyAdminsBadge';


### PR DESCRIPTION
The 'new since vx' badge is part of the title of the Function App page, which means that it also tries to include it in the tab title - results in raw HTML.

This PR uses a dedicated title for the page to prevent this from happening.