### PR TITLE
chore(parametertable): streamline current badges style with used in parameter tables

### DIFF
--- a/src/components/Badges.js
+++ b/src/components/Badges.js
@@ -27,25 +27,28 @@ export function OnlyFolderAdminsBadge() {
   });
 }
 
-export function NewSinceBadge({ version }) {
+export function NewSinceBadge({ version, style }) {
   return Badge({
     title: `New since ${version}`,
     tooltip: `Feature included since **Invictus ${version}**.`,
     backgroundColor: '#059669',
     color: 'white',
+    style,
   });
 }
 
-export function DeprecatedSinceBadge({ version, label }) {
+export function DeprecatedSinceBadge({ version, note, style }) {
   return Badge({
     title: `Deprecated since ${version}`,
-    tooltip: `Feature deprecated since **Invictus ${version}**. ${label}`,
+    tooltip: `Feature deprecated since **Invictus ${version}**. ${note}`,
     backgroundColor: '#b55d00',
     color: 'white',
+    style,
+
   });
 }
 
-export function Badge({ title, tooltip, backgroundColor = '#b55d00', color = 'white' }) {
+export function Badge({ title, tooltip, backgroundColor = '#b55d00', color = 'white', style }) {
   useTooltipStyles();
 
   const badgeRef = useRef(null);
@@ -83,7 +86,7 @@ export function Badge({ title, tooltip, backgroundColor = '#b55d00', color = 'wh
     <>
       <span
         ref={badgeRef}
-        style={{ position: 'relative', display: 'inline-block', marginLeft: '8px', textTransform: 'none', fontWeight: 'bold' }}
+        style={{ position: 'relative', display: 'inline-block', marginLeft: '8px', textTransform: 'none', fontWeight: 'bold', ...style }}
         role="button"
         aria-pressed={pinned}
         aria-describedby={visible ? tooltipId : undefined}
@@ -108,6 +111,7 @@ export function Badge({ title, tooltip, backgroundColor = '#b55d00', color = 'wh
             userSelect: 'none',
             borderBottom: '1.5px dotted currentColor',
             '--badge-accent': backgroundColor,
+            ...style,
           }}
         >
           {title}

--- a/src/components/ParameterTable.tsx
+++ b/src/components/ParameterTable.tsx
@@ -7,6 +7,7 @@ import { useLocation, useHistory } from "@docusaurus/router";
 import highlightStyles from "./highlight.module.css";
 import inputStyles from "./tableSearchInput.module.css";
 import rowStyles from "./resultRow.module.css";
+import { NewSinceBadge, DeprecatedSinceBadge, DefaultValueBadge } from "./Badges";
 
 export type Parameter = {
   name: string;
@@ -15,7 +16,7 @@ export type Parameter = {
   properties?: Parameter[];
   required?: boolean;
   default?: any;
-  deprecatedSince?: string;
+  deprecatedSince?: { version: string; note: string };
   newSince?: string;
 };
 
@@ -281,8 +282,8 @@ export default function ParameterTable({ parameters: rawParameters, fixedTags = 
                 {p.default !== undefined && (
                   <span className={rowStyles.badgeDefault}>default: <code>{p.default.toString()}</code></span>
                 )}
-                {p.newSince && <span className={rowStyles.badgeSince}>new since {p.newSince}</span>}
-                {p.deprecatedSince && <span className={rowStyles.badgeDeprecated}>deprecated since: {p.deprecatedSince}</span>}
+                {p.newSince && <NewSinceBadge version={p.newSince} style={{ fontSize: '0.875rem', marginLeft: '0px' }} />}
+                {p.deprecatedSince && <DeprecatedSinceBadge version={p.deprecatedSince.version} note={p.deprecatedSince.note} style={{ fontSize: '0.875rem', marginLeft: '0px' }} />}
               </div>
             )}
           </td>
@@ -431,7 +432,11 @@ const resultCountStyle: React.CSSProperties = {
   color: "var(--ifm-font-color-base)",
 };
 
-const codeStyle: React.CSSProperties = { color: "var(--ifm-color-primary)", backgroundColor: "var(--ifm-background-color)" };
+const codeStyle: React.CSSProperties = {
+  fontSize: "0.95rem",
+  color: "var(--ifm-color-primary)",
+  backgroundColor: "var(--ifm-background-color)"
+};
 
 const tagBadgeStyle: React.CSSProperties = {
   marginRight: "6px",

--- a/src/components/resultRow.module.css
+++ b/src/components/resultRow.module.css
@@ -127,6 +127,7 @@
 
 .descCell p {
   margin: 0;
+  font-size: 1rem;
 }
 
 :global([data-theme='dark']) .descCell {
@@ -139,8 +140,8 @@
   overflow: hidden;
 }
 
-.row + .row,
-.answerPanel + .row {
+.row+.row,
+.answerPanel+.row {
   margin-top: 4px;
 }
 
@@ -273,24 +274,42 @@
   margin-top: 2px;
 }
 
-.badgeRequired, .badgeDeprecated, .badgeSince, .badgeDefault {
-  font-size: 0.75rem;
-  padding: 1px 4px;
-  border-radius: 3px;
+.badgeRequired,
+.badgeDeprecated,
+.badgeSince,
+.badgeDefault {
+  font-size: 0.8rem;
+  padding: 2px 6px;
+  border-radius: 4px;
   color: white;
 }
 
-.badgeRequired code, .badgeDeprecated code, .badgeSince code, .badgeDefault code {
-  font-size: 0.75rem !important;
+.badgeRequired code,
+.badgeDeprecated code,
+.badgeSince code,
+.badgeDefault code {
+  font-size: 0.8rem !important;
   background: none;
   padding: 0;
   color: inherit;
 }
 
-.badgeRequired   { background-color: #b10006; }
-.badgeDeprecated { background-color: #b55d00; }
-.badgeSince      { background-color: #059669; }
-.badgeDefault    { background-color: var(--ifm-color-emphasis-200); color: var(--ifm-font-color-base); }
+.badgeRequired {
+  background-color: #b10006;
+}
+
+.badgeDeprecated {
+  background-color: #b55d00;
+}
+
+.badgeSince {
+  background-color: #059669;
+}
+
+.badgeDefault {
+  background-color: var(--ifm-color-emphasis-200);
+  color: var(--ifm-font-color-base);
+}
 
 .versionBadge {
   font-size: 0.7rem;
@@ -595,8 +614,15 @@
 }
 
 /* Rotate ↑/↓ glyphs to make consistent left/right arrows */
-.kbdRotateLeft  { display: inline-block; transform: rotate(-90deg); }
-.kbdRotateRight { display: inline-block; transform: rotate(90deg); }
+.kbdRotateLeft {
+  display: inline-block;
+  transform: rotate(-90deg);
+}
+
+.kbdRotateRight {
+  display: inline-block;
+  transform: rotate(90deg);
+}
 
 .footerAskAi {
   display: inline-flex;
@@ -709,12 +735,33 @@
   line-height: 1.6;
 }
 
-.aiAnswer p { margin: 0 0 0.6em; font-size: inherit; }
-.aiAnswer p:last-child { margin-bottom: 0; }
-.aiAnswer strong { font-weight: 600; }
-.aiAnswer em { font-style: italic; }
-.aiAnswer ul, .aiAnswer ol { margin: 0.4em 0 0.6em 1.2em; padding: 0; }
-.aiAnswer li { margin-bottom: 0.2em; font-size: inherit; }
+.aiAnswer p {
+  margin: 0 0 0.6em;
+  font-size: inherit;
+}
+
+.aiAnswer p:last-child {
+  margin-bottom: 0;
+}
+
+.aiAnswer strong {
+  font-weight: 600;
+}
+
+.aiAnswer em {
+  font-style: italic;
+}
+
+.aiAnswer ul,
+.aiAnswer ol {
+  margin: 0.4em 0 0.6em 1.2em;
+  padding: 0;
+}
+
+.aiAnswer li {
+  margin-bottom: 0.2em;
+  font-size: inherit;
+}
 
 .aiPlaceholder {
   font-size: 0.875rem;
@@ -881,8 +928,15 @@
 }
 
 @keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
+
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
 }
 
 /* ─────────────────────────────────────────────
@@ -948,13 +1002,19 @@
     font-size: 0.7rem;
   }
 
-  .badgeRequired, .badgeDeprecated, .badgeSince, .badgeDefault {
-    font-size: 0.72rem;
+  .badgeRequired,
+  .badgeDeprecated,
+  .badgeSince,
+  .badgeDefault {
+    font-size: 0.8rem;
     padding: 1px 4px;
   }
 
-  .badgeRequired code, .badgeDeprecated code, .badgeSince code, .badgeDefault code {
-    font-size: 0.72rem !important;
+  .badgeRequired code,
+  .badgeDeprecated code,
+  .badgeSince code,
+  .badgeDefault code {
+    font-size: 0.8rem !important;
   }
 
   .nameCell {

--- a/src/data/dashboard.v6.bicep.parameters.json
+++ b/src/data/dashboard.v6.bicep.parameters.json
@@ -749,7 +749,10 @@
   {
     "name": "logAnalyticsWorkspaceImportFunctionV2Cron",
     "description": "The time period in which the automatically Azure Functions timer trigger [imports Azure Logic Apps diagnostic traces](/dashboard/flows/import-flow-traces/import-flows-via-la).",
-    "deprecatedSince": "v6.2, will be removed in v7, support for automatically triggering importing stops.",
+    "deprecatedSince": {
+      "version": "v6.2",
+      "note": "will be removed in v7, support for automatically triggering importing stops."
+    },
     "default": "0 */10 * * * *",
     "tags": [
       "importing",
@@ -760,7 +763,10 @@
     "name": "logAnalyticsWorkspaceMaxNoOfRows",
     "description": "The maximum amount of rows to query the Azure Log Analytics workspace to automatically [import Azure Logic Apps diagnostic traces](/dashboard/flows/import-flow-traces/import-flows-via-la).",
     "default": "1000",
-    "deprecatedSince": "v6.2, will be removed in v7, support for automatically triggering importing stops.",
+    "deprecatedSince": {
+      "version": "v6.2",
+      "note": "will be removed in v7, support for automatically triggering importing stops."
+    },
     "tags": [
       "importing",
       "deprecated"
@@ -803,7 +809,10 @@
   {
     "name": "flowBlobArchiverFunctionCron",
     "description": "The CRON expression that represents the time period in which flow trace information is archived.",
-    "deprecatedSince": "v6.2, will be removed in v7, clearing happens via Cosmos DB for MongoDB TTL policies.",
+    "deprecatedSince": {
+      "version": "v6.2",
+      "note": "will be removed in v7, clearing happens via Cosmos DB for MongoDB TTL policies."
+    },
     "default": "0 0 */3 * * *",
     "tags": [
       "storage",
@@ -814,7 +823,10 @@
     "name": "hashCacheClearFunctionCron",
     "description": "The CRON expression that represents the time period in which to clear the Dashboard storage backend cache.",
     "default": "0 00 03 * * *",
-    "deprecatedSince": "v6.2, will be removed in v7, clearing happens via Azure Storage Account policies.",
+    "deprecatedSince": {
+      "version": "v6.2",
+      "note": "will be removed in v7, clearing happens via Azure Storage Account policies."
+    },
     "tags": [
       "storage",
       "deprecated"
@@ -824,7 +836,10 @@
     "name": "workFlowEventsClearFunctionCron",
     "description": "The CRON expression that represents the time period in which to clear the Azure Logic Apps workflow Dashboard backend storage.",
     "default": "0 */15 * * * *",
-    "deprecatedSince": "v6.2, will be removed in v7, clearing happens via Cosmos DB for MongoDB TTL policies.",
+    "deprecatedSince": {
+      "version": "v6.2",
+      "note": "will be removed in v7, clearing happens via Cosmos DB for MongoDB TTL policies."
+    },
     "tags": [
       "storage",
       "deprecated"
@@ -834,7 +849,10 @@
     "name": "azureWebJobsWorkFlowEventsClearFunctionDisabled",
     "description": "Indicates whether the Azure Functions timer trigger should be disabled, meaning the Azure Logic Apps workflow Dashboard backend storage won't be cleared.",
     "default": "true",
-    "deprecatedSince": "v6.2, will be removed in v7, clearing happens via Cosmos DB for MongoDB TTL policies.",
+    "deprecatedSince": {
+      "version": "v6.2",
+      "note": "will be removed in v7, clearing happens via Cosmos DB for MongoDB TTL policies."
+    },
     "tags": [
       "storage",
       "deprecated"
@@ -844,7 +862,10 @@
     "name": "maxMessageStatusCacheInDay",
     "description": "The maximum amount of messages per day cached during importing.",
     "default": "60",
-    "deprecatedSince": "v6.2, will be removed in v7, caching happens independently now.",
+    "deprecatedSince": {
+      "version": "v6.2",
+      "note": "will be removed in v7, caching happens independently now."
+    },
     "tags": [
       "storage",
       "scaling",


### PR DESCRIPTION
Use the same 'badge style' for the Bicep parameter tables, so that it becomes streamlined as well as more readable. Plus, using the existing badges for versioning/deprecation, we can make use of tooltips instead of bloating the already big parameter table.