### PR TITLE
feat(framework.diagrams): streamline component diagrams with invictus style

### DIFF
--- a/src/components/ApiPlayground.module.css
+++ b/src/components/ApiPlayground.module.css
@@ -229,6 +229,11 @@
   padding: 0;
 }
 
+/* Reduce admonition heading size when rendered inside a parameter description */
+.paramDesc :global([class*="admonitionHeading"]) {
+  font-size: 0.75rem;
+}
+
 /* ─── Status tabs ────────────────────────────────────────────────────────── */
 
 .statusTabs {
@@ -697,6 +702,11 @@
   color: var(--ifm-color-emphasis-700);
   margin: 0;
   padding: 0;
+}
+
+/* Reduce admonition heading size when rendered inside a parameter description */
+.paramDesc :global([class*="admonitionHeading"]) {
+  font-size: 0.75rem;
 }
 
 /* ─── Status tabs ────────────────────────────────────────────────────────── */

--- a/src/components/ApiPlayground.tsx
+++ b/src/components/ApiPlayground.tsx
@@ -31,7 +31,7 @@ export type ApiParameter = {
   name: string;
   type: string;
   required?: boolean;
-  description: string;
+  description: string | React.ReactNode;
   /** Optional React nodes (e.g. <NewSinceBadge />) rendered after the required badge. */
   badges?: React.ReactNode;
 };
@@ -47,6 +47,7 @@ export type ApiPlaygroundProps = {
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   path: string;
   description?: React.ReactNode;
+  parametersTitle?: string;
   parameters?: ApiParameter[];
   request?: unknown;
   responses: ApiResponse[];
@@ -69,14 +70,14 @@ function capitalize(s: string): string {
 
 function typeBadgeClass(type: string): string {
   switch (type.toLowerCase()) {
-    case "string":  return rowStyles.typeBadgeString;
+    case "string": return rowStyles.typeBadgeString;
     case "int":
     case "integer": return rowStyles.typeBadgeInt;
     case "bool":
     case "boolean": return rowStyles.typeBadgeBool;
-    case "object":  return rowStyles.typeBadgeObject;
-    case "array":   return rowStyles.typeBadgeArray;
-    default:        return rowStyles.typeBadgeDefault;
+    case "object": return rowStyles.typeBadgeObject;
+    case "array": return rowStyles.typeBadgeArray;
+    default: return rowStyles.typeBadgeDefault;
   }
 }
 
@@ -86,6 +87,7 @@ export default function ApiPlayground({
   method,
   path,
   description,
+  parametersTitle,
   parameters,
   request,
   responses,
@@ -186,7 +188,7 @@ export default function ApiPlayground({
 
           {parameters && parameters.length > 0 && (
             <div className={styles.section}>
-              <p className={styles.sectionLabel} aria-hidden="true">Body Parameters</p>
+              <p className={styles.sectionLabel} aria-hidden="true">{parametersTitle || "Body Parameters"}</p>
               <ul className={styles.paramList} role="list">
                 {parameters.map((p) => (
                   <li key={p.name} className={styles.param}>
@@ -200,7 +202,10 @@ export default function ApiPlayground({
                         <span className={styles.paramBadgeSlot}>{p.badges}</span>
                       )}
                     </div>
-                    <MarkdownText className={styles.paramDesc}>{p.description}</MarkdownText>
+                    {typeof p.description === "string"
+                      ? <MarkdownText className={styles.paramDesc}>{p.description}</MarkdownText>
+                      : <div className={styles.paramDesc}>{p.description}</div>
+                    }
                   </li>
                 ))}
               </ul>

--- a/src/components/Diagrams/ComponentFlowDiagram.tsx
+++ b/src/components/Diagrams/ComponentFlowDiagram.tsx
@@ -1,0 +1,355 @@
+import React from "react";
+import { useColorMode } from "@docusaurus/theme-common";
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+
+export interface FlowRow {
+  input: string;
+  opTitle: string;
+  opSubtitle: string;
+  output: string;
+  /** Storage backend label shown as a footer inside the op block, e.g. "Blob Storage" */
+  storageLabel?: string;
+}
+
+export interface ComponentFlowDiagramProps {
+  /** Component display name — shown in the header */
+  name: string;
+  /** Short tagline — shown below the name in the header */
+  tagline: string;
+  /** FontAwesome icon definition — path data and viewBox are derived automatically */
+  icon: IconDefinition;
+  /** Set to true for icons that require evenodd fill-rule (e.g. faGear) */
+  iconEvenOdd?: boolean;
+  /** One entry per flow row rendered below the header */
+  rows: FlowRow[];
+}
+
+const LIGHT = {
+  header: "#065b68",
+  accent: "#014550",
+  fill: "#ffffff",
+  stroke: "#b8c0c2",
+  text: "#1c1e21",
+  arrow: "#065b68",
+  rowTitle: "#ffffff",
+  rowSubtitle: "#a0dde5",
+  headerSubtitle: "#a0dde5",
+};
+
+const DARK = {
+  header: "#1a5f68",
+  accent: "#2a8f9c",
+  fill: "#374151",
+  stroke: "#6B7280",
+  text: "#D1D5DB",
+  arrow: "#2a8f9c",
+  rowTitle: "#ffffff",
+  rowSubtitle: "#a0dde5",
+  headerSubtitle: "#a0dde5",
+};
+
+const HEADING_FONT = "var(--ifm-heading-font-family, 'Bitter', Georgia, serif)";
+const BODY_FONT =
+  "var(--ifm-font-family-base, 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif)";
+
+// Matches --ifm-global-radius (0.4rem at 16px base = 6.4px)
+const RX = 6;
+// Matches --ifm-alert-border-left-width
+const ACCENT_W = 5;
+
+const W = 380;
+const HEADER_Y = 10;
+const HEADER_H = 54;
+const ICON_BADGE_W = 46;
+const ICON_SIZE = 28;
+const ROW_H = 66; // taller to accommodate the storage-backend footer
+const ROW_GAP = 12;
+const FIRST_ROW_Y = HEADER_Y + HEADER_H + 10;
+
+export default function ComponentFlowDiagram({
+  name,
+  tagline,
+  icon,
+  iconEvenOdd = false,
+  rows,
+}: ComponentFlowDiagramProps) {
+  const { colorMode } = useColorMode();
+  const c = colorMode === "dark" ? DARK : LIGHT;
+
+  const totalH =
+    FIRST_ROW_Y + rows.length * ROW_H + (rows.length - 1) * ROW_GAP + 8;
+
+  // Derive dimensions directly from the FA icon definition
+  const iconVbWidth = icon.icon[0];   // e.g. 512 or 576
+  const iconVbHeight = icon.icon[1];  // always 512
+  const iconPathData = icon.icon[4] as string;
+
+  const iconScale = ICON_SIZE / iconVbWidth;
+  const iconTx = 8 + (ICON_BADGE_W - iconVbWidth * iconScale) / 2;
+  const iconTy = HEADER_Y + (HEADER_H - iconVbHeight * iconScale) / 2;
+
+  // Unique base id — keeps marker + clipPath ids collision-free across diagrams
+  const uid = `${name.replace(/[^a-zA-Z0-9]/g, "")}`;
+
+  return (
+    <div style={{ maxWidth: 560, margin: "2rem auto" }}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="100%"
+        viewBox={`0 0 ${W} ${totalH}`}
+        role="img"
+        aria-label={`${name} — flow diagram`}
+      >
+        <defs>
+          {/* Arrow marker — absolute pixel size (markerUnits="userSpaceOnUse") so it
+              stays proportional regardless of stroke width */}
+          <marker
+            id={`arr-${uid}`}
+            markerWidth="5"
+            markerHeight="4"
+            refX="5"
+            refY="2"
+            orient="auto"
+            markerUnits="userSpaceOnUse"
+          >
+            <polygon points="0 0, 5 2, 0 4" fill={c.arrow} />
+          </marker>
+
+          {/* Header clip — keeps icon badge inside the rounded header */}
+          <clipPath id={`hdr-${uid}`}>
+            <rect x="8" y={HEADER_Y} width="364" height={HEADER_H} rx={RX} />
+          </clipPath>
+
+          {/* Per-row clip paths for the accent bars */}
+          {rows.map((_, i) => {
+            const rowY = FIRST_ROW_Y + i * (ROW_H + ROW_GAP);
+            return (
+              <React.Fragment key={i}>
+                <clipPath id={`in-${uid}-${i}`}>
+                  <rect x="8" y={rowY} width="96" height={ROW_H} rx={RX} />
+                </clipPath>
+                <clipPath id={`op-${uid}-${i}`}>
+                  <rect x="114" y={rowY} width="140" height={ROW_H} rx={RX} />
+                </clipPath>
+                <clipPath id={`out-${uid}-${i}`}>
+                  <rect x="264" y={rowY} width="108" height={ROW_H} rx={RX} />
+                </clipPath>
+              </React.Fragment>
+            );
+          })}
+        </defs>
+
+        {/* ── Header ── */}
+        <rect
+          x="8"
+          y={HEADER_Y}
+          width="364"
+          height={HEADER_H}
+          fill={c.header}
+          rx={RX}
+        />
+        {/* Icon badge — clipped to the header rounded shape */}
+        <rect
+          x="8"
+          y={HEADER_Y}
+          width={ICON_BADGE_W}
+          height={HEADER_H}
+          fill={c.accent}
+          clipPath={`url(#hdr-${uid})`}
+        />
+        <path
+          d={iconPathData}
+          fill="white"
+          fillRule={iconEvenOdd ? "evenodd" : undefined}
+          transform={`translate(${iconTx.toFixed(2)},${iconTy.toFixed(2)}) scale(${iconScale.toFixed(6)})`}
+        />
+        <text
+          x="213"
+          y={HEADER_Y + 19}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="14"
+          fontWeight="700"
+          fill="#ffffff"
+          style={{ fontFamily: HEADING_FONT }}
+        >
+          {name}
+        </text>
+        <text
+          x="213"
+          y={HEADER_Y + 36}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="10"
+          fill={c.headerSubtitle}
+          style={{ fontFamily: BODY_FONT }}
+        >
+          {tagline}
+        </text>
+
+        {/* ── Rows ── */}
+        {rows.map((row, i) => {
+          const rowY = FIRST_ROW_Y + i * (ROW_H + ROW_GAP);
+          const midY = rowY + ROW_H / 2;
+
+          return (
+            <React.Fragment key={i}>
+              {/* Input block */}
+              <rect
+                x="8"
+                y={rowY}
+                width="96"
+                height={ROW_H}
+                fill={c.fill}
+                stroke={c.stroke}
+                strokeWidth="1.5"
+                rx={RX}
+              />
+              <rect
+                x="8"
+                y={rowY}
+                width={ACCENT_W}
+                height={ROW_H}
+                fill={c.stroke}
+                clipPath={`url(#in-${uid}-${i})`}
+              />
+              <text
+                x="56"
+                y={midY}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize="12"
+                fill={c.text}
+                style={{ fontFamily: BODY_FONT }}
+              >
+                {row.input}
+              </text>
+
+              {/* Arrow input → op */}
+              <line
+                x1="106"
+                y1={midY}
+                x2="113"
+                y2={midY}
+                stroke={c.arrow}
+                strokeWidth="1.5"
+                markerEnd={`url(#arr-${uid})`}
+              />
+
+              {/* Op block */}
+              <rect
+                x="114"
+                y={rowY}
+                width="140"
+                height={ROW_H}
+                fill={c.header}
+                stroke={c.accent}
+                strokeWidth="1"
+                rx={RX}
+              />
+              <rect
+                x="114"
+                y={rowY}
+                width={ACCENT_W}
+                height={ROW_H}
+                fill={c.accent}
+                clipPath={`url(#op-${uid}-${i})`}
+              />
+              {/* Op title — shifted up when a storage footer is present */}
+              <text
+                x="184"
+                y={row.storageLabel ? rowY + 20 : midY - 9}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize="13"
+                fontWeight="600"
+                fill={c.rowTitle}
+                style={{ fontFamily: HEADING_FONT }}
+              >
+                {row.opTitle}
+              </text>
+              <text
+                x="184"
+                y={row.storageLabel ? rowY + 33 : midY + 9}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize="9"
+                fill={c.rowSubtitle}
+                style={{ fontFamily: BODY_FONT }}
+              >
+                {row.opSubtitle}
+              </text>
+              {/* Storage backend footer — thin separator + label */}
+              {row.storageLabel && (
+                <>
+                  <line
+                    x1={114 + ACCENT_W + 3}
+                    y1={rowY + 45}
+                    x2={254 - 3}
+                    y2={rowY + 45}
+                    stroke="rgba(255,255,255,0.18)"
+                    strokeWidth="0.75"
+                  />
+                  <text
+                    x="184"
+                    y={rowY + 56}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize="8"
+                    fill={c.rowSubtitle}
+                    style={{ fontFamily: BODY_FONT, opacity: 0.8 }}
+                  >
+                    {row.storageLabel}
+                  </text>
+                </>
+              )}
+
+              {/* Arrow op → output */}
+              <line
+                x1="256"
+                y1={midY}
+                x2="263"
+                y2={midY}
+                stroke={c.arrow}
+                strokeWidth="1.5"
+                markerEnd={`url(#arr-${uid})`}
+              />
+
+              {/* Output block */}
+              <rect
+                x="264"
+                y={rowY}
+                width="108"
+                height={ROW_H}
+                fill={c.fill}
+                stroke={c.stroke}
+                strokeWidth="1.5"
+                rx={RX}
+              />
+              <rect
+                x="264"
+                y={rowY}
+                width={ACCENT_W}
+                height={ROW_H}
+                fill={c.stroke}
+                clipPath={`url(#out-${uid}-${i})`}
+              />
+              <text
+                x="318"
+                y={midY}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize="12"
+                fill={c.text}
+                style={{ fontFamily: BODY_FONT }}
+              >
+                {row.output}
+              </text>
+            </React.Fragment>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+

--- a/src/components/Diagrams/PubSubFlowDiagram.tsx
+++ b/src/components/Diagrams/PubSubFlowDiagram.tsx
@@ -94,7 +94,7 @@ export default function PubSubFlow() {
         </text>
         <line x1={22 + ACCENT_W + 3} y1="220" x2="218" y2="220" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
         <text x="122" y="228" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
-          Azure Blob Storage
+          Azure Service Bus + Blob Storage
         </text>
         {/* HTTP badge */}
         <rect x="182" y="163" width="40" height="18" rx="3" fill={c.badge} />
@@ -116,7 +116,7 @@ export default function PubSubFlow() {
         </text>
         <line x1={301 + ACCENT_W + 3} y1="120" x2="497" y2="120" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
         <text x="401" y="128" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
-          Azure Blob Storage
+          Azure Service Bus + Blob Storage
         </text>
         {/* HTTP badge */}
         <rect x="461" y="63" width="40" height="18" rx="3" fill={c.badge} />
@@ -134,7 +134,7 @@ export default function PubSubFlow() {
         </text>
         <line x1={301 + ACCENT_W + 3} y1="220" x2="497" y2="220" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
         <text x="401" y="228" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
-          Azure Blob Storage
+          Azure Service Bus + Blob Storage
         </text>
         {/* HTTP badge */}
         <rect x="461" y="163" width="40" height="18" rx="3" fill={c.badge} />

--- a/src/components/Diagrams/PubSubFlowMobileDiagram.tsx
+++ b/src/components/Diagrams/PubSubFlowMobileDiagram.tsx
@@ -42,32 +42,32 @@ const DARK = {
   badge: "#c27311",
 };
 
-export default function PubSubFlow() {
+export default function PubSubFlowMobile() {
   const { colorMode } = useColorMode();
   const c = colorMode === "dark" ? DARK : LIGHT;
 
   return (
-    <div style={{ maxWidth: 680, margin: "2rem auto" }}>
+    <div style={{ maxWidth: 380, margin: "2rem auto" }}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="100%"
-        viewBox="0 0 528 271"
+        viewBox="0 0 249 519"
         role="img"
-        aria-label="PubSub message flow diagram"
+        aria-label="PubSub message flow diagram for mobile layout"
       >
         <defs>
-          <marker id="arr-PubSub" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+          <marker id="arr-PubSubMobile" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse">
             <polygon points="0 0, 8 3, 0 6" fill={c.arrow} />
           </marker>
           {/* Clip paths keep the accent bar inside the rounded block corners */}
-          <clipPath id="clip-ps-publish">
+          <clipPath id="clip-psm-publish">
             <rect x="22" y="172" width="200" height={INV_H} rx={RX} />
           </clipPath>
-          <clipPath id="clip-ps-subscribe">
-            <rect x="301" y="72" width="200" height={INV_H} rx={RX} />
+          <clipPath id="clip-psm-subscribe">
+            <rect x="22" y="320" width="200" height={INV_H} rx={RX} />
           </clipPath>
-          <clipPath id="clip-ps-acknowledge">
-            <rect x="301" y="172" width="200" height={INV_H} rx={RX} />
+          <clipPath id="clip-psm-acknowledge">
+            <rect x="22" y="420" width="200" height={INV_H} rx={RX} />
           </clipPath>
         </defs>
 
@@ -84,11 +84,11 @@ export default function PubSubFlow() {
           Receive
         </text>
 
-        <line x1="122" y1="136" x2="122" y2="169" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-PubSub)" />
+        <line x1="122" y1="136" x2="122" y2="169" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-PubSubMobile)" />
 
         {/* Publish (Invictus) */}
         <rect x="22" y="172" width="200" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
-        <rect x="22" y="172" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-ps-publish)" />
+        <rect x="22" y="172" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-psm-publish)" />
         <text x="122" y="192" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
           Publish
         </text>
@@ -102,50 +102,49 @@ export default function PubSubFlow() {
           HTTP
         </text>
 
+        {/* Dashed arrow: Publish → Subscribe (via Service Bus) */}
+        <line x1="122" y1="236" x2="122" y2="317" stroke={c.arrow} strokeWidth="1.5" strokeDasharray="6 4" markerEnd="url(#arr-PubSubMobile)" />
+
         {/* ══ Subscriber Logic App ══ */}
-        <text x="289" y="44" fontSize="13" fontWeight="700" fill={c.labelText} style={{ fontFamily: HEADING_FONT }}>
+        <text x="10" y="292" fontSize="13" fontWeight="700" fill={c.labelText} style={{ fontFamily: HEADING_FONT }}>
           Subscriber Logic App
         </text>
-        <rect x="289" y="52" width="224" height="204" rx="4" fill="none" stroke={c.containerStroke} strokeWidth="1.5" />
+        <rect x="10" y="300" width="224" height="204" rx="4" fill="none" stroke={c.containerStroke} strokeWidth="1.5" />
 
         {/* Subscribe (Invictus) */}
-        <rect x="301" y="72" width="200" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
-        <rect x="301" y="72" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-ps-subscribe)" />
-        <text x="401" y="92" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
+        <rect x="22" y="320" width="200" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
+        <rect x="22" y="320" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-psm-subscribe)" />
+        <text x="122" y="340" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
           Subscribe
         </text>
-        <line x1={301 + ACCENT_W + 3} y1="120" x2="497" y2="120" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
-        <text x="401" y="128" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
+        <line x1={22 + ACCENT_W + 3} y1="368" x2="218" y2="368" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
+        <text x="122" y="376" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
           Azure Blob Storage
         </text>
         {/* HTTP badge */}
-        <rect x="461" y="63" width="40" height="18" rx="3" fill={c.badge} />
-        <text x="481" y="72" textAnchor="middle" dominantBaseline="middle" fontSize="10" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
+        <rect x="182" y="311" width="40" height="18" rx="3" fill={c.badge} />
+        <text x="202" y="320" textAnchor="middle" dominantBaseline="middle" fontSize="10" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
           HTTP
         </text>
 
-        <line x1="401" y1="136" x2="401" y2="169" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-PubSub)" />
+        <line x1="122" y1="384" x2="122" y2="417" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-PubSubMobile)" />
 
         {/* Acknowledge (Invictus) */}
-        <rect x="301" y="172" width="200" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
-        <rect x="301" y="172" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-ps-acknowledge)" />
-        <text x="401" y="192" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
+        <rect x="22" y="420" width="200" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
+        <rect x="22" y="420" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-psm-acknowledge)" />
+        <text x="122" y="440" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
           Acknowledge
         </text>
-        <line x1={301 + ACCENT_W + 3} y1="220" x2="497" y2="220" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
-        <text x="401" y="228" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
+        <line x1={22 + ACCENT_W + 3} y1="468" x2="218" y2="468" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
+        <text x="122" y="476" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
           Azure Blob Storage
         </text>
         {/* HTTP badge */}
-        <rect x="461" y="163" width="40" height="18" rx="3" fill={c.badge} />
-        <text x="481" y="172" textAnchor="middle" dominantBaseline="middle" fontSize="10" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
+        <rect x="182" y="411" width="40" height="18" rx="3" fill={c.badge} />
+        <text x="202" y="420" textAnchor="middle" dominantBaseline="middle" fontSize="10" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
           HTTP
         </text>
-
-        {/* Z-arrow: Publish → Subscribe (via Service Bus) */}
-        <path d="M 222,192 H 261 V 92 H 301" fill="none" stroke={c.arrow} strokeWidth="1.5" strokeDasharray="6 4" markerEnd="url(#arr-PubSub)" />
       </svg>
     </div>
   );
 }
-

--- a/src/components/Diagrams/PubSubFlowMobileDiagram.tsx
+++ b/src/components/Diagrams/PubSubFlowMobileDiagram.tsx
@@ -94,7 +94,7 @@ export default function PubSubFlowMobile() {
         </text>
         <line x1={22 + ACCENT_W + 3} y1="220" x2="218" y2="220" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
         <text x="122" y="228" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
-          Azure Blob Storage
+          Azure Service Bus + Blob Storage
         </text>
         {/* HTTP badge */}
         <rect x="182" y="163" width="40" height="18" rx="3" fill={c.badge} />
@@ -119,7 +119,7 @@ export default function PubSubFlowMobile() {
         </text>
         <line x1={22 + ACCENT_W + 3} y1="368" x2="218" y2="368" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
         <text x="122" y="376" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
-          Azure Blob Storage
+          Azure Service Bus + Blob Storage
         </text>
         {/* HTTP badge */}
         <rect x="182" y="311" width="40" height="18" rx="3" fill={c.badge} />
@@ -137,7 +137,7 @@ export default function PubSubFlowMobile() {
         </text>
         <line x1={22 + ACCENT_W + 3} y1="468" x2="218" y2="468" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
         <text x="122" y="476" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
-          Azure Blob Storage
+          Azure Service Bus + Blob Storage
         </text>
         {/* HTTP badge */}
         <rect x="182" y="411" width="40" height="18" rx="3" fill={c.badge} />

--- a/src/components/Diagrams/SequenceControllerFlowDiagram.tsx
+++ b/src/components/Diagrams/SequenceControllerFlowDiagram.tsx
@@ -1,154 +1,151 @@
 import React from "react";
+import { useColorMode } from "@docusaurus/theme-common";
 
-// ── Shared CSS-variable palette (mirrors TimeSequencerFlowDiagram) ────────────
-const c = {
-  primary:       "var(--ifm-color-primary)",
-  primaryLight:  "var(--ifm-color-primary-light)",
-  secondary:     "var(--ifm-color-secondary)",
-  secondaryDark: "var(--ifm-color-secondary-darker)",
-  warning:       "var(--ifm-color-warning)",
-  bg:            "var(--ifm-background-color)",
-  text:          "var(--ifm-font-color-base)",
-} as const;
+const HEADING_FONT = "var(--ifm-heading-font-family, 'Bitter', Georgia, serif)";
+const BODY_FONT =
+  "var(--ifm-font-family-base, 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif)";
 
-// ── Style presets ─────────────────────────────────────────────────────────────
-const ACCENT = 8;
+// Invictus block dimensions — matches ComponentFlowDiagram proportions
+const INV_H = 56; // taller to accommodate the storage-backend footer
+const RX = 6;
+const ACCENT_W = 8;
 
-const invRect  = { fill: c.primaryLight, stroke: c.primary,   strokeWidth: 1   } as const;
-const regRect  = { fill: c.bg,           stroke: c.secondary, strokeWidth: 1.5 } as const;
-const warnRect = { fill: c.warning,      stroke: c.warning,   strokeWidth: 1   } as const;
-const badgeRect = { fill: c.warning } as const;
+const LIGHT = {
+  arrow: "#065b68",
+  boxBg: "#ffffff",
+  boxStroke: "#b8c0c2",
+  bodyText: "#1c1e21",
+  invBox: "#065b68",
+  invStroke: "#014550",
+  invAccent: "#014550",
+  invTitle: "#ffffff",
+  invSubtitle: "#a0dde5",
+  badge: "#ff970f",
+  controlTask: "#ff970f",
+};
 
-const solid  = { stroke: c.primaryLight, strokeWidth: 1.5, fill: "none" } as const;
-const dashed = { stroke: c.primaryLight, strokeWidth: 1.5, fill: "none", strokeDasharray: "6 4" } as const;
+const DARK = {
+  arrow: "#2a8f9c",
+  boxBg: "#374151",
+  boxStroke: "#6B7280",
+  bodyText: "#D1D5DB",
+  invBox: "#1a5f68",
+  invStroke: "#2a8f9c",
+  invAccent: "#2a8f9c",
+  invTitle: "#ffffff",
+  invSubtitle: "#a0dde5",
+  badge: "#c27311",
+  controlTask: "#c27311",
+};
 
-const invText  = { fontSize: 13, fill: "#ffffff", fontWeight: 600 } as const;
-const regText  = { fontSize: 13, fill: c.text } as const;
-const badgeText = { fontSize: 9, fill: "#ffffff", fontWeight: 700, letterSpacing: 0.5 } as const;
-
-// ── Dimensions ────────────────────────────────────────────────────────────────
-const MW = 150;   // block width
-const BH = 44;    // block height
-
-const CX    = 200;              // main column center
-const mainX = CX - MW / 2;     // 125
-
-const Y_RECEIVE  = 12;
-const Y_GET      = 82;
-const Y_WAIT     = 172;
-const Y_CTRL     = 258;
-const Y_COMPLETE = 364;         // extra gap suggests omitted customer steps
-
-const VB_W = 480;
-const VB_H = Y_COMPLETE + BH + 28;   // 436
-
-// ── Shared helpers ────────────────────────────────────────────────────────────
-function Block({ x, y, w, label, type }: {
-  x: number; y: number; w: number; label: string;
-  type: "regular" | "invictus" | "warning";
-}) {
-  const rStyle = type === "invictus" ? invRect : type === "warning" ? warnRect : regRect;
-  const tStyle = type === "regular"  ? regText : invText;
-  const accentFill = type === "invictus" ? c.primary : type === "regular" ? c.secondary : null;
+export default function SequenceControllerFlow() {
+  const { colorMode } = useColorMode();
+  const c = colorMode === "dark" ? DARK : LIGHT;
 
   return (
-    <>
-      <rect x={x} y={y} width={w} height={BH} rx={2} style={rStyle} />
-      {accentFill && (
-        <rect x={x} y={y} width={ACCENT} height={BH} style={{ fill: accentFill }} />
-      )}
-      <text x={x + w / 2} y={y + BH / 2} textAnchor="middle" dominantBaseline="middle" style={tStyle}>
-        {label}
-      </text>
-    </>
+    <div style={{ maxWidth: 640, margin: "2rem auto" }}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="100%"
+        viewBox="0 0 480 472"
+        role="img"
+        aria-label="Sequence Controller flow diagram"
+      >
+        <defs>
+          <marker id="arr-SeqController" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+            <polygon points="0 0, 8 3, 0 6" fill={c.arrow} />
+          </marker>
+          {/* Clip paths keep the accent bar inside the rounded block corners */}
+          <clipPath id="clip-sc-get">
+            <rect x="125" y="82" width="150" height={INV_H} rx={RX} />
+          </clipPath>
+          <clipPath id="clip-sc-wait">
+            <rect x="125" y="184" width="150" height={INV_H} rx={RX} />
+          </clipPath>
+          <clipPath id="clip-sc-complete">
+            <rect x="125" y="388" width="150" height={INV_H} rx={RX} />
+          </clipPath>
+        </defs>
+
+        {/* ══ Receive ══ */}
+        <rect x="125" y="12" width="150" height="44" fill={c.boxBg} stroke={c.boxStroke} strokeWidth="1.5" />
+        <rect x="125" y="12" width="8" height="44" fill={c.boxStroke} />
+        <text x="200" y="34" textAnchor="middle" dominantBaseline="middle" fontSize="13" fill={c.bodyText} style={{ fontFamily: BODY_FONT }}>
+          Receive
+        </text>
+
+        <line x1="200" y1="56" x2="200" y2="78" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-SeqController)" />
+
+        {/* ══ Get sequence number (Invictus — y=82, h=56) ══ */}
+        <rect x="125" y="82" width="150" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
+        <rect x="125" y="82" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-sc-get)" />
+        <text x="200" y="100" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
+          Get sequence number
+        </text>
+        <line x1={125 + ACCENT_W + 3} y1="122" x2="271" y2="122" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
+        <text x="200" y="130" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
+          Azure Blob Storage
+        </text>
+        {/* HTTP badge */}
+        <rect x="235" y="73" width="40" height="18" rx="3" fill={c.badge} />
+        <text x="255" y="82" textAnchor="middle" dominantBaseline="middle" fontSize="9" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
+          HTTP
+        </text>
+
+        {/* Arrow: Get seq# bottom (82+56=138) → Wait for sequence (y=184), gap=46 */}
+        <line x1="200" y1="138" x2="200" y2="180" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-SeqController)" />
+
+        {/* ══ Wait for sequence (Invictus — y=184, h=56) ══ */}
+        <rect x="125" y="184" width="150" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
+        <rect x="125" y="184" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-sc-wait)" />
+        <text x="200" y="202" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
+          Wait for sequence
+        </text>
+        <line x1={125 + ACCENT_W + 3} y1="224" x2="271" y2="224" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
+        <text x="200" y="232" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
+          Azure Blob Storage
+        </text>
+        {/* HTTP-callback badge */}
+        <rect x="191" y="175" width="84" height="18" rx="3" fill={c.badge} />
+        <text x="233" y="184" textAnchor="middle" dominantBaseline="middle" fontSize="9" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
+          HTTP-callback
+        </text>
+
+        {/* Arrow: Wait for seq bottom (184+56=240) → Control task (y=278), gap=38 */}
+        <line x1="200" y1="240" x2="200" y2="278" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-SeqController)" />
+
+        {/* ══ Control task (customer work) ══ */}
+        <rect x="125" y="282" width="150" height="44" fill={c.controlTask} stroke={c.controlTask} strokeWidth="1" />
+        <text x="200" y="304" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill="#ffffff" style={{ fontFamily: HEADING_FONT }}>
+          Control task
+        </text>
+
+        {/* Arrow: Control task bottom (282+44=326) → Complete sequence (y=384), gap=58 */}
+        <line x1="200" y1="326" x2="200" y2="384" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-SeqController)" />
+
+        {/* ══ Complete sequence (Invictus — y=388, h=56) ══ */}
+        <rect x="125" y="388" width="150" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
+        <rect x="125" y="388" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-sc-complete)" />
+        <text x="200" y="406" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
+          Complete sequence
+        </text>
+        <line x1={125 + ACCENT_W + 3} y1="428" x2="271" y2="428" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
+        <text x="200" y="436" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
+          Azure Blob Storage
+        </text>
+        {/* HTTP badge */}
+        <rect x="235" y="379" width="40" height="18" rx="3" fill={c.badge} />
+        <text x="255" y="388" textAnchor="middle" dominantBaseline="middle" fontSize="9" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
+          HTTP
+        </text>
+
+        {/* Dashed right loop: right of Get seq# → right of Wait for seq (passes sequence number) */}
+        <path d="M 275,100 H 452 V 202 H 275" fill="none" stroke={c.arrow} strokeWidth="1.5" strokeDasharray="6 4" markerEnd="url(#arr-SeqController)" />
+
+        {/* Dashed left loop: left of Wait for seq → left of Complete seq (passes sequence number) */}
+        <path d="M 125,202 H 28 V 406 H 125" fill="none" stroke={c.arrow} strokeWidth="1.5" strokeDasharray="6 4" markerEnd="url(#arr-SeqController)" />
+      </svg>
+    </div>
   );
 }
 
-function Badge({ rightX: rx, topY, label }: { rightX: number; topY: number; label: string }) {
-  const bw = label === "HTTP" ? 40 : 84;
-  const bx = rx - bw;
-  const by = topY - 9;
-  return (
-    <>
-      <rect x={bx} y={by} width={bw} height={18} rx={3} style={badgeRect} />
-      <text x={bx + bw / 2} y={by + 9} textAnchor="middle" dominantBaseline="middle" style={badgeText}>
-        {label}
-      </text>
-    </>
-  );
-}
-
-// ── Diagram ───────────────────────────────────────────────────────────────────
-export default function SequenceControllerFlowDiagram(): JSX.Element {
-  return (
-    <svg
-      viewBox={`0 0 ${VB_W} ${VB_H}`}
-      role="img"
-      aria-labelledby="scfd-title scfd-desc"
-      style={{ width: "100%", maxWidth: 520, display: "block", margin: "2rem auto",
-               fontFamily: "inherit", overflow: "visible" }}
-    >
-      <title id="scfd-title">Sequence Controller Logic App workflow</title>
-      <desc id="scfd-desc">
-        A Receive trigger feeds into Get sequence number (HTTP), then into Wait for
-        sequence (HTTP-callback). A dashed arrow from Get sequence number loops back
-        into Wait for sequence, indicating the same sequence number is reused. After
-        waiting, a Control task performs the customer work. A dashed arrow from Wait
-        for sequence loops down to Complete sequence (HTTP), which finalises the slot.
-      </desc>
-      <defs>
-        <marker id="scfd-arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-          <polygon points="0 0, 8 3, 0 6" style={{ fill: c.primaryLight }} />
-        </marker>
-      </defs>
-
-      {/* ── Receive ────────────────────────────────────────────────────────── */}
-      <Block x={mainX} y={Y_RECEIVE} w={MW} label="Receive" type="regular" />
-
-      {/* Receive → Get sequence number */}
-      <line x1={CX} y1={Y_RECEIVE + BH} x2={CX} y2={Y_GET - 4}
-        style={solid} markerEnd="url(#scfd-arr)" />
-
-      {/* ── Get sequence number ─────────────────────────────────────────────── */}
-      <Block x={mainX} y={Y_GET} w={MW} label="Get sequence number" type="invictus" />
-      <Badge rightX={mainX + MW} topY={Y_GET} label="HTTP" />
-
-      {/* Get sequence number → Wait for sequence */}
-      <line x1={CX} y1={Y_GET + BH} x2={CX} y2={Y_WAIT - 4}
-        style={solid} markerEnd="url(#scfd-arr)" />
-
-      {/* ── Wait for sequence ───────────────────────────────────────────────── */}
-      <Block x={mainX} y={Y_WAIT} w={MW} label="Wait for sequence" type="invictus" />
-      <Badge rightX={mainX + MW} topY={Y_WAIT} label="HTTP-callback" />
-
-      {/* Wait for sequence → Control task */}
-      <line x1={CX} y1={Y_WAIT + BH} x2={CX} y2={Y_CTRL - 4}
-        style={solid} markerEnd="url(#scfd-arr)" />
-
-      {/* ── Control task ────────────────────────────────────────────────────── */}
-      <Block x={mainX} y={Y_CTRL} w={MW} label="Control task" type="warning" />
-
-      {/* Control task → Complete sequence */}
-      <line x1={CX} y1={Y_CTRL + BH} x2={CX} y2={Y_COMPLETE - 4}
-        style={solid} markerEnd="url(#scfd-arr)" />
-
-      {/* ── Complete sequence ───────────────────────────────────────────────── */}
-      <Block x={mainX} y={Y_COMPLETE} w={MW} label="Complete sequence" type="invictus" />
-      <Badge rightX={mainX + MW} topY={Y_COMPLETE} label="HTTP" />
-
-      {/* ── Dashed right loop: Get seq # (right) → Wait for sequence (right) ── */}
-      <path
-        d={`M${mainX + MW},${Y_GET + BH / 2} H${VB_W - 28} V${Y_WAIT + BH / 2} H${mainX + MW}`}
-        style={dashed}
-        markerEnd="url(#scfd-arr)"
-      />
-
-      {/* ── Dashed left loop: Wait for sequence (left) → Complete sequence (left) ── */}
-      <path
-        d={`M${mainX},${Y_WAIT + BH / 2} H${28} V${Y_COMPLETE + BH / 2} H${mainX}`}
-        style={dashed}
-        markerEnd="url(#scfd-arr)"
-      />
-    </svg>
-  );
-}

--- a/src/components/Diagrams/SequenceControllerSortDiagram.tsx
+++ b/src/components/Diagrams/SequenceControllerSortDiagram.tsx
@@ -1,120 +1,139 @@
 import React from "react";
+import { useColorMode } from "@docusaurus/theme-common";
 
-// ── Shared CSS-variable palette (mirrors TimeSequencerFlowDiagram) ────────────
-const c = {
-  primary: "var(--ifm-color-primary)",
-  primaryLight: "var(--ifm-color-primary-light)",
-  primaryDark: "var(--ifm-color-primary-darker)",
-  primaryLightest: "var(--ifm-color-primary-lightest)",
-  secondary: "var(--ifm-color-secondary)",
-  secondaryDark: "var(--ifm-color-secondary-darker)",
-  warning: "var(--ifm-color-warning)",
-  bg: "var(--ifm-background-color)",
-  text: "var(--ifm-font-color-base)",
-} as const;
+const HEADING_FONT = "var(--ifm-heading-font-family, 'Bitter', Georgia, serif)";
 
-// ── Block style presets (same as flow diagram) ────────────────────────────────
-const ACCENT = 6;
-
-// Sequence number → visual type
-//   1: invictus  — teal filled
-//   2: step      — dark filled
-//   3: warning   — orange filled
-//   4: regular   — outlined
-type BlockType = "invictus" | "step" | "warning" | "regular";
-
-const TYPES: Record<1 | 2 | 3 | 4, BlockType> = {
-  1: "invictus",
-  2: "step",
-  3: "warning",
-  4: "regular",
+const LIGHT = {
+  slot1Box: "#2a8f9c",
+  slot1Accent: "#014550",
+  slot1Text: "#ffffff",
+  slot2Box: "#6c7374",
+  slot2Text: "#ffffff",
+  slot3Box: "#01363f",
+  slot3Text: "#ffffff",
+  slot4Box: "#ffffff",
+  slot4Stroke: "#b8c0c2",
+  slot4Text: "#1c1e21",
+  separatorFill: "#6c7374",
 };
 
-// ── Dimensions ────────────────────────────────────────────────────────────────
-const BW = 72;
-const BH = 44;
-const GAP = 12;
-const STEP = BW + GAP;        // 84
-const BY = 18;
-const PAD = 16;
-const GROUP_W = 4 * BW + 3 * GAP;   // 324
+const DARK = {
+  slot1Box: "#2a8f9c",
+  slot1Accent: "#014550",
+  slot1Text: "#ffffff",
+  slot2Box: "#6B7280",
+  slot2Text: "#ffffff",
+  slot3Box: "#013c46",
+  slot3Text: "#a0dde5",
+  slot4Box: "#1F2937",
+  slot4Stroke: "#6B7280",
+  slot4Text: "#D1D5DB",
+  separatorFill: "#9CA3AF",
+};
 
-const LEFT_X = PAD;
-const SEP_X = PAD + GROUP_W + 32;
-const RIGHT_X = SEP_X + 32;
-const VB_W = RIGHT_X + GROUP_W + PAD;
-const VB_H = BY + BH + BY;
-
-// ── Block component ───────────────────────────────────────────────────────────
-function Block({ x, type, label }: { x: number; type: BlockType; label: string }) {
-  const rectStyle =
-    type === "invictus" ? { fill: c.primaryLightest } :
-      type === "step" ? { fill: c.secondaryDark } :
-        type === "warning" ? { fill: c.primaryDark, } :
-          { fill: c.bg, stroke: c.secondary, strokeWidth: 1.5 };
-
-  const textStyle =
-    type === "regular"
-      ? { fontSize: 18, fontWeight: 700, fill: c.text, fontFamily: "var(--ifm-font-family-monospace)" }
-      : { fontSize: 18, fontWeight: 700, fill: "#ffffff", fontFamily: "var(--ifm-font-family-monospace)" };
-
-  const accentFill =
-    type === "invictus" ? c.primary :
-      type === "regular" ? c.secondary : null;
-
+function SequenceBox({
+  x,
+  label,
+  fill,
+  textFill,
+  accentFill,
+  strokeFill,
+}: {
+  x: number;
+  label: string;
+  fill: string;
+  textFill: string;
+  accentFill?: string;
+  strokeFill?: string;
+}) {
   return (
     <>
-      <rect x={x} y={BY} width={BW} height={BH} rx={2} style={rectStyle} />
-      <text x={x + BW / 2} y={BY + BH / 2}
-        textAnchor="middle" dominantBaseline="middle" style={textStyle}>
+      <rect
+        x={x}
+        y="18"
+        width="72"
+        height="44"
+        rx="2"
+        fill={fill}
+        stroke={strokeFill}
+        strokeWidth={strokeFill ? "1.5" : undefined}
+      />
+      {accentFill && <rect x={x} y="18" width="6" height="44" fill={accentFill} />}
+      {strokeFill && <rect x={x} y="18" width="6" height="44" fill={strokeFill} />}
+      <text
+        x={x + 36}
+        y="40"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="18"
+        fontWeight="700"
+        fill={textFill}
+        style={{ fontFamily: HEADING_FONT }}
+      >
         {label}
       </text>
     </>
   );
 }
 
-// ── Diagram ───────────────────────────────────────────────────────────────────
-export default function SequenceControllerSortDiagram(): JSX.Element {
-  // Left: arrival order — 2, 1, 3, 4
-  // Right: sorted order — 1, 2, 3, 4
-  const left: Array<1 | 2 | 3 | 4> = [2, 1, 3, 4];
-  const right: Array<1 | 2 | 3 | 4> = [1, 2, 3, 4];
+export default function SequenceControllerSort() {
+  const { colorMode } = useColorMode();
+  const c = colorMode === "dark" ? DARK : LIGHT;
 
   return (
-    <svg
-      viewBox={`0 0 ${VB_W} ${VB_H}`}
-      role="img"
-      aria-labelledby="scsd-title scsd-desc"
-      style={{
-        width: "100%", maxWidth: 760, display: "block",
-        margin: "2rem auto", fontFamily: "inherit", overflow: "visible"
-      }}
-    >
-      <title id="scsd-title">Sequence Controller sorting diagram</title>
-      <desc id="scsd-desc">
-        Four workflow executions with sequence numbers 2, 1, 3 and 4 arrive in
-        unordered sequence. After the Sequence Controller processes them they are
-        executed in order: 1, 2, 3, 4.
-      </desc>
-
-      {/* Left group — unordered arrival */}
-      {left.map((seq, i) => (
-        <Block key={`L-${seq}`} x={LEFT_X + i * STEP} type={TYPES[seq]} label={String(seq)} />
-      ))}
-
-      {/* ">" separator */}
-      <text
-        x={SEP_X} y={BY + BH / 2}
-        textAnchor="middle" dominantBaseline="middle"
-        style={{ fontSize: 26, fontWeight: 700, fill: c.secondaryDark }}
+    <div style={{ maxWidth: 820, margin: "2rem auto" }}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="100%"
+        viewBox="0 0 744 80"
+        role="img"
+        aria-label="Sequence Controller sorting diagram"
       >
-        {">"}
-      </text>
-
-      {/* Right group — ordered execution */}
-      {right.map((seq, i) => (
-        <Block key={`R-${seq}`} x={RIGHT_X + i * STEP} type={TYPES[seq]} label={String(seq)} />
-      ))}
-    </svg>
+        <SequenceBox x={16} label="2" fill={c.slot2Box} textFill={c.slot2Text} />
+        <SequenceBox
+          x={100}
+          label="1"
+          fill={c.slot1Box}
+          accentFill={c.slot1Accent}
+          textFill={c.slot1Text}
+        />
+        <SequenceBox x={184} label="3" fill={c.slot3Box} textFill={c.slot3Text} />
+        <SequenceBox
+          x={268}
+          label="4"
+          fill={c.slot4Box}
+          strokeFill={c.slot4Stroke}
+          textFill={c.slot4Text}
+        />
+        <text
+          x="372"
+          y="40"
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="26"
+          fontWeight="700"
+          fill={c.separatorFill}
+          style={{ fontFamily: HEADING_FONT }}
+        >
+          {">"}
+        </text>
+        <SequenceBox
+          x={404}
+          label="1"
+          fill={c.slot1Box}
+          accentFill={c.slot1Accent}
+          textFill={c.slot1Text}
+        />
+        <SequenceBox x={488} label="2" fill={c.slot2Box} textFill={c.slot2Text} />
+        <SequenceBox x={572} label="3" fill={c.slot3Box} textFill={c.slot3Text} />
+        <SequenceBox
+          x={656}
+          label="4"
+          fill={c.slot4Box}
+          strokeFill={c.slot4Stroke}
+          textFill={c.slot4Text}
+        />
+      </svg>
+    </div>
   );
 }

--- a/src/components/Diagrams/TimeSequencerFlowDiagram.tsx
+++ b/src/components/Diagrams/TimeSequencerFlowDiagram.tsx
@@ -1,180 +1,164 @@
 import React from "react";
+import { useColorMode } from "@docusaurus/theme-common";
 
-const c = {
-  primary:       "var(--ifm-color-primary)",
-  primaryLight:  "var(--ifm-color-primary-light)",
-  secondary:     "var(--ifm-color-secondary)",
-  secondaryDark: "var(--ifm-color-secondary-darker)",
-  warning:       "var(--ifm-color-warning)",
-  bg:            "var(--ifm-background-color)",
-  text:          "var(--ifm-font-color-base)",
-} as const;
+const HEADING_FONT = "var(--ifm-heading-font-family, 'Bitter', Georgia, serif)";
+const BODY_FONT =
+  "var(--ifm-font-family-base, 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif)";
 
-// ── Style presets ─────────────────────────────────────────────────────────────
-const ACCENT = 8;
+// Invictus block dimensions — matches ComponentFlowDiagram proportions
+const INV_H = 56; // taller to accommodate the storage-backend footer
+const RX = 6;
+const ACCENT_W = 8;
 
-const invRect   = { fill: c.primaryLight, stroke: c.primary,    strokeWidth: 1   } as const;
-const regRect   = { fill: c.bg,           stroke: c.secondary,  strokeWidth: 1.5 } as const;
-const stepRect  = { fill: c.secondaryDark                                         } as const;
-const termRect  = { fill: "#b91c1c"                                               } as const;
-const groupRect = { fill: c.bg,           stroke: c.secondary,  strokeWidth: 1   } as const;
-const badgeRect = { fill: c.warning                                               } as const;
+const LIGHT = {
+  arrow: "#065b68",
+  boxBg: "#ffffff",
+  boxStroke: "#b8c0c2",
+  bodyText: "#1c1e21",
+  invBox: "#065b68",
+  invStroke: "#014550",
+  invAccent: "#014550",
+  invTitle: "#ffffff",
+  invSubtitle: "#a0dde5",
+  stepBox: "#6c7374",
+  stepTitle: "#ffffff",
+  termBox: "#b91c1c",
+  groupBorder: "#b8c0c2",
+  badge: "#ff970f",
+};
 
-const solid  = { stroke: c.primaryLight, strokeWidth: 1.5, fill: "none"                      } as const;
-const dashed = { stroke: c.primaryLight, strokeWidth: 1.5, fill: "none", strokeDasharray: "6 4" } as const;
+const DARK = {
+  arrow: "#2a8f9c",
+  boxBg: "#374151",
+  boxStroke: "#6B7280",
+  bodyText: "#D1D5DB",
+  invBox: "#1a5f68",
+  invStroke: "#2a8f9c",
+  invAccent: "#2a8f9c",
+  invTitle: "#ffffff",
+  invSubtitle: "#a0dde5",
+  stepBox: "#4B5563",
+  stepTitle: "#ffffff",
+  termBox: "#dc2626",
+  groupBorder: "#374151",
+  badge: "#c27311",
+};
 
-const invText  = { fontSize: 13, fill: "#ffffff", fontWeight: 600 } as const;
-const regText  = { fontSize: 13, fill: c.text                     } as const;
-const stepText = { fontSize: 13, fill: "#ffffff", fontWeight: 600,
-                   fontFamily: "var(--ifm-font-family-monospace)"  } as const;
-const badgeText = { fontSize: 9, fill: "#ffffff", fontWeight: 700, letterSpacing: 0.5 } as const;
-
-// ── Dimensions ────────────────────────────────────────────────────────────────
-const MW = 150;   // main block width  (Receive, Wait for exec., Switch)
-const BW = 130;   // branch block width (Stop, Start, Terminate, Complete exec.)
-const BH = 44;    // block height
-
-const CX  = 200;  // center X — main column
-const LCX = 108;  // center X — left branch (Stop, Terminate)
-const RCX = 323;  // center X — right branch (Start, Complete exec.)
-
-const mainX  = CX  - MW / 2;  // 125
-const leftX  = LCX - BW / 2;  // 43
-const rightX = RCX - BW / 2;  // 258
-
-const Y_RECEIVE = 12;
-const Y_WAIT    = 82;
-const Y_SWITCH  = 168;
-const Y_BRANCH  = 228;  // branch junction (stem from Switch bottom)
-const Y_SS      = 252;  // Stop / Start top
-const Y_TC      = 332;  // Terminate / Complete exec. top
-
-const GRP_X = 20;
-const GRP_Y = 150;
-const GRP_W = rightX + BW + 20 - GRP_X;            // 408 - 20 = 388
-const GRP_H = Y_TC + BH + 22 - GRP_Y;              // 396 - 150 = 246
-
-const VB_W  = 490;
-const VB_H  = Y_TC + BH + 30;                       // 406
-
-// ── Shared helpers ────────────────────────────────────────────────────────────
-function Block({ x, y, w, label, type }: {
-  x: number; y: number; w: number; label: string;
-  type: "regular" | "invictus" | "step" | "terminate";
-}) {
-  const rStyle =
-    type === "invictus"  ? invRect  :
-    type === "step"      ? stepRect :
-    type === "terminate" ? termRect :
-    regRect;
-  const tStyle = type === "regular" ? regText : type === "step" ? stepText : invText;
+export default function TimeSequencerFlow() {
+  const { colorMode } = useColorMode();
+  const c = colorMode === "dark" ? DARK : LIGHT;
 
   return (
-    <>
-      <rect x={x} y={y} width={w} height={BH} rx={2} style={rStyle} />
-      {(type === "regular" || type === "invictus") && (
-        <rect x={x} y={y} width={ACCENT} height={BH}
-          style={{ fill: type === "regular" ? c.secondary : c.primary }} />
-      )}
-      <text x={x + w / 2} y={y + BH / 2} textAnchor="middle" dominantBaseline="middle" style={tStyle}>
-        {label}
-      </text>
-    </>
-  );
-}
+    <div style={{ maxWidth: 640, margin: "2rem auto" }}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="100%"
+        viewBox="0 0 490 418"
+        role="img"
+        aria-label="Time Sequencer flow diagram"
+      >
+        <defs>
+          <marker
+            id="arr-TimeSequencer"
+            markerWidth="8"
+            markerHeight="6"
+            refX="7"
+            refY="3"
+            orient="auto"
+            markerUnits="userSpaceOnUse"
+          >
+            <polygon points="0 0, 8 3, 0 6" fill={c.arrow} />
+          </marker>
+          {/* Clip paths keep the accent bar inside the rounded block corners */}
+          <clipPath id="clip-ts-wait">
+            <rect x="125" y="82" width="150" height={INV_H} rx={RX} />
+          </clipPath>
+          <clipPath id="clip-ts-complete">
+            <rect x="258" y="344" width="130" height={INV_H} rx={RX} />
+          </clipPath>
+        </defs>
 
-function Badge({ rightX: rx, topY, label }: { rightX: number; topY: number; label: string }) {
-  const bw = label === "HTTP" ? 40 : 84;
-  const bx = rx - bw;
-  const by = topY - 9;
-  return (
-    <>
-      <rect x={bx} y={by} width={bw} height={18} rx={3} style={badgeRect} />
-      <text x={bx + bw / 2} y={by + 9} textAnchor="middle" dominantBaseline="middle" style={badgeText}>
-        {label}
-      </text>
-    </>
-  );
-}
+        {/* ══ Receive ══ */}
+        <rect x="125" y="12" width="150" height="44" fill={c.boxBg} stroke={c.boxStroke} strokeWidth="1.5" />
+        <rect x="125" y="12" width="8" height="44" fill={c.boxStroke} />
+        <text x="200" y="34" textAnchor="middle" dominantBaseline="middle" fontSize="13" fill={c.bodyText} style={{ fontFamily: BODY_FONT }}>
+          Receive
+        </text>
 
-// ── Diagram ───────────────────────────────────────────────────────────────────
-export default function TimeSequencerFlowDiagram(): JSX.Element {
-  return (
-    <svg
-      viewBox={`0 0 ${VB_W} ${VB_H}`}
-      role="img"
-      aria-labelledby="tsfd-title tsfd-desc"
-      style={{ width: "100%", maxWidth: 520, display: "block", margin: "2rem auto",
-               fontFamily: "inherit", overflow: "visible" }}
-    >
-      <title id="tsfd-title">Time Sequencer Logic App workflow</title>
-      <desc id="tsfd-desc">
-        A Receive trigger feeds into a Wait for execution HTTP-callback endpoint.
-        A Switch block then branches: the Stop path leads to a Terminate action,
-        while the Start path leads to a Complete execution HTTP endpoint.
-        A dashed arrow from Wait for execution loops back to Complete execution.
-      </desc>
-      <defs>
-        <marker id="tsfd-arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-          <polygon points="0 0, 8 3, 0 6" style={{ fill: c.primaryLight }} />
-        </marker>
-      </defs>
+        <line x1="200" y1="56" x2="200" y2="78" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-TimeSequencer)" />
 
-      {/* ── Receive ─────────────────────────────────────────────────────────── */}
-      <Block x={mainX} y={Y_RECEIVE} w={MW} label="Receive" type="regular" />
+        {/* ══ Wait for exec. (Invictus — INV_H=56) ══ */}
+        <rect x="125" y="82" width="150" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
+        <rect x="125" y="82" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-ts-wait)" />
+        <text x="200" y="100" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
+          Wait for exec.
+        </text>
+        <line x1={125 + ACCENT_W + 3} y1="122" x2="271" y2="122" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
+        <text x="200" y="130" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
+          Azure Blob Storage
+        </text>
+        {/* HTTP-callback badge */}
+        <rect x="191" y="73" width="84" height="18" rx="3" fill={c.badge} />
+        <text x="233" y="82" textAnchor="middle" dominantBaseline="middle" fontSize="9" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
+          HTTP-callback
+        </text>
 
-      {/* Receive → Wait for exec. */}
-      <line x1={CX} y1={Y_RECEIVE + BH} x2={CX} y2={Y_WAIT - 4}
-        style={solid} markerEnd="url(#tsfd-arr)" />
+        {/* Arrow: Wait for exec. bottom (82+56=138) → group container (y=162) */}
+        <line x1="200" y1="138" x2="200" y2="176" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-TimeSequencer)" />
 
-      {/* ── Wait for exec. ──────────────────────────────────────────────────── */}
-      <Block x={mainX} y={Y_WAIT} w={MW} label="Wait for exec." type="invictus" />
-      <Badge rightX={mainX + MW} topY={Y_WAIT} label="HTTP-callback" />
+        {/* ══ Group container — shifted +12 from original ══ */}
+        <rect x="20" y="162" width="388" height="248" rx="6" fill="none" stroke={c.groupBorder} strokeWidth="1" />
 
-      {/* Wait for exec. → Switch */}
-      <line x1={CX} y1={Y_WAIT + BH} x2={CX} y2={Y_SWITCH - 4}
-        style={solid} markerEnd="url(#tsfd-arr)" />
+        {/* ══ Switch ══ */}
+        <rect x="125" y="180" width="150" height="44" rx="2" fill={c.stepBox} />
+        <text x="200" y="202" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.stepTitle} style={{ fontFamily: HEADING_FONT }}>
+          Switch
+        </text>
 
-      {/* ── Group box (Switch + branches) ───────────────────────────────────── */}
-      <rect x={GRP_X} y={GRP_Y} width={GRP_W} height={GRP_H} rx={6} style={groupRect} />
+        {/* Branch lines */}
+        <line x1="200" y1="224" x2="200" y2="240" stroke={c.arrow} strokeWidth="1.5" />
+        <line x1="108" y1="240" x2="323" y2="240" stroke={c.arrow} strokeWidth="1.5" />
+        <line x1="108" y1="240" x2="108" y2="260" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-TimeSequencer)" />
+        <line x1="323" y1="240" x2="323" y2="260" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-TimeSequencer)" />
 
-      {/* ── Switch ──────────────────────────────────────────────────────────── */}
-      <Block x={mainX} y={Y_SWITCH} w={MW} label="Switch" type="step" />
+        {/* ══ Stop / Start ══ */}
+        <rect x="43" y="264" width="130" height="44" rx="2" fill={c.stepBox} />
+        <text x="108" y="286" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.stepTitle} style={{ fontFamily: HEADING_FONT }}>
+          Stop
+        </text>
+        <rect x="258" y="264" width="130" height="44" rx="2" fill={c.stepBox} />
+        <text x="323" y="286" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.stepTitle} style={{ fontFamily: HEADING_FONT }}>
+          Start
+        </text>
 
-      {/* Switch → branch junction (stem + crossbar) */}
-      <line x1={CX}  y1={Y_SWITCH + BH} x2={CX}  y2={Y_BRANCH} style={solid} />
-      <line x1={LCX} y1={Y_BRANCH}      x2={RCX} y2={Y_BRANCH} style={solid} />
-      {/* Branch → Stop */}
-      <line x1={LCX} y1={Y_BRANCH} x2={LCX} y2={Y_SS - 4}
-        style={solid} markerEnd="url(#tsfd-arr)" />
-      {/* Branch → Start */}
-      <line x1={RCX} y1={Y_BRANCH} x2={RCX} y2={Y_SS - 4}
-        style={solid} markerEnd="url(#tsfd-arr)" />
+        <line x1="108" y1="308" x2="108" y2="340" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-TimeSequencer)" />
+        <line x1="323" y1="308" x2="323" y2="340" stroke={c.arrow} strokeWidth="1.5" markerEnd="url(#arr-TimeSequencer)" />
 
-      {/* ── Stop / Start ────────────────────────────────────────────────────── */}
-      <Block x={leftX}  y={Y_SS} w={BW} label="Stop"  type="step" />
-      <Block x={rightX} y={Y_SS} w={BW} label="Start" type="step" />
+        {/* ══ Terminate ══ */}
+        <rect x="43" y="344" width="130" height="44" rx="2" fill={c.termBox} />
+        <text x="108" y="366" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill="#ffffff" style={{ fontFamily: HEADING_FONT }}>
+          Terminate
+        </text>
 
-      {/* Stop → Terminate */}
-      <line x1={LCX} y1={Y_SS + BH} x2={LCX} y2={Y_TC - 4}
-        style={solid} markerEnd="url(#tsfd-arr)" />
-      {/* Start → Complete exec. */}
-      <line x1={RCX} y1={Y_SS + BH} x2={RCX} y2={Y_TC - 4}
-        style={solid} markerEnd="url(#tsfd-arr)" />
+        {/* ══ Complete exec. (Invictus — INV_H=56, y=344) ══ */}
+        <rect x="258" y="344" width="130" height={INV_H} rx={RX} fill={c.invBox} stroke={c.invStroke} strokeWidth="1" />
+        <rect x="258" y="344" width={ACCENT_W} height={INV_H} fill={c.invAccent} clipPath="url(#clip-ts-complete)" />
+        <text x="323" y="362" textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={c.invTitle} style={{ fontFamily: HEADING_FONT }}>
+          Complete exec.
+        </text>
+        <line x1={258 + ACCENT_W + 3} y1="384" x2="385" y2="384" stroke="rgba(255,255,255,0.18)" strokeWidth="0.75" />
+        <text x="323" y="392" textAnchor="middle" dominantBaseline="middle" fontSize="9" fill={c.invSubtitle} style={{ fontFamily: BODY_FONT, opacity: 0.8 }}>
+          Azure Blob Storage
+        </text>
+        {/* HTTP badge */}
+        <rect x="348" y="335" width="40" height="18" rx="3" fill={c.badge} />
+        <text x="368" y="344" textAnchor="middle" dominantBaseline="middle" fontSize="9" fontWeight="700" letterSpacing="0.5" fill="#ffffff" style={{ fontFamily: BODY_FONT }}>
+          HTTP
+        </text>
 
-      {/* ── Terminate ───────────────────────────────────────────────────────── */}
-      <Block x={leftX}  y={Y_TC} w={BW} label="Terminate"     type="terminate" />
-
-      {/* ── Complete exec. ──────────────────────────────────────────────────── */}
-      <Block x={rightX} y={Y_TC} w={BW} label="Complete exec." type="invictus" />
-      <Badge rightX={rightX + BW} topY={Y_TC} label="HTTP" />
-
-      {/* ── Dashed return arrow: Wait for exec. (right) → Complete exec. (right) ── */}
-      <path
-        d={`M${mainX + MW},${Y_WAIT + BH / 2} H${VB_W - 24} V${Y_TC + BH / 2} H${rightX + BW}`}
-        style={dashed}
-        markerEnd="url(#tsfd-arr)"
-      />
-    </svg>
+        {/* Dashed return arrow: right of Wait for exec. → right of Complete exec. */}
+        <path d="M 275,100 H 466 V 362 H 388" fill="none" stroke={c.arrow} strokeWidth="1.5" strokeDasharray="6 4" markerEnd="url(#arr-TimeSequencer)" />
+      </svg>
+    </div>
   );
 }

--- a/src/components/Diagrams/TimeSequencerSortDiagram.tsx
+++ b/src/components/Diagrams/TimeSequencerSortDiagram.tsx
@@ -1,124 +1,110 @@
 import React from "react";
+import { useColorMode } from "@docusaurus/theme-common";
 
-// ── Shared CSS-variable palette (mirrors TimeSequencerFlowDiagram) ─────────────
-const c = {
-  primary: "var(--ifm-color-primary)",
-  primaryDark: "var(--ifm-color-primary-darker)",
-  primaryDarker: "var(--ifm-color-primary-darkest)",
-  primaryLightest: "var(--ifm-color-primary-lightest)",
-  primaryLight: "var(--ifm-color-primary-light)",
-  secondary: "var(--ifm-color-secondary)",
-  secondaryDark: "var(--ifm-color-secondary-darker)",
-  warning: "var(--ifm-color-warning)",
-  bg: "var(--ifm-background-color)",
-  text: "var(--ifm-font-color-base)",
-} as const;
+const HEADING_FONT = "var(--ifm-heading-font-family, 'Bitter', Georgia, serif)";
+const BODY_FONT =
+  "var(--ifm-font-family-base, 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif)";
 
-// ── Block style presets (same as flow diagram) ────────────────────────────────
-const ACCENT = 6;
-
-// Block identity → visual type
-//   A (1:05): invictus  — teal filled   (like "Wait for exec." / "Complete exec.")
-//   B (0:40): step      — dark filled   (like "Switch" / "Stop" / "Start")
-//   C (1:23): warning   — orange filled (like the HTTP-callback badge)
-//   D (2:01): regular   — outlined      (like "Receive")
-type BlockType = "invictus" | "step" | "warning" | "regular";
-
-const TYPES: Record<"A" | "B" | "C" | "D", BlockType> = {
-  A: "invictus",
-  B: "step",
-  C: "warning",
-  D: "regular",
+const LIGHT = {
+  aBox: "#065b68",
+  aText: "#ffffff",
+  bBox: "#002b32",
+  bText: "#ffffff",
+  cBox: "#6c7374",
+  cText: "#ffffff",
+  dBox: "#2a8f9c",
+  dText: "#1c1e21",
+  separatorFill: "#b8c0c2",
 };
 
-const LABELS = { A: "1:05", B: "0:40", C: "1:23", D: "2:01" } as const;
+const DARK = {
+  aBox: "#1a5f68",
+  aText: "#ffffff",
+  bBox: "#002b32",
+  bText: "#ffffff",
+  cBox: "#4B5563",
+  cText: "#ffffff",
+  dBox: "#374151",
+  dText: "#D1D5DB",
+  separatorFill: "#6B7280",
+};
 
-// ── Dimensions ────────────────────────────────────────────────────────────────
-const BW = 72;          // block width
-const BH = 44;          // block height (same as flow diagram)
-const GAP = 12;
-const STEP = BW + GAP;    // 84
-const BY = 18;
-const PAD = 16;
-const GROUP_W = 4 * BW + 3 * GAP;   // 324
-
-const LEFT_X = PAD;
-const SEP_X = PAD + GROUP_W + 32;
-const RIGHT_X = SEP_X + 32;
-const VB_W = RIGHT_X + GROUP_W + PAD;
-const VB_H = BY + BH + BY;
-
-// ── Block component ───────────────────────────────────────────────────────────
-function Block({ x, type, label }: { x: number; type: BlockType; label: string }) {
-  const rectStyle =
-    type === "invictus" ? { fill: c.primaryLight } :
-      type === "step" ? { fill: c.primaryDarker } :
-        type === "warning" ? { fill: c.secondaryDark } :
-          { fill: c.primaryLightest };
-
-  const textStyle =
-    type === "regular"
-      ? { fontSize: 15, fontWeight: 700, fill: c.text, fontFamily: "var(--ifm-font-family-monospace)" }
-      : { fontSize: 15, fontWeight: 700, fill: "#ffffff", fontFamily: "var(--ifm-font-family-monospace)" };
-
-  const accentFill =
-    type === "invictus" ? c.primary :
-      type === "regular" ? c.secondary : null;
-
+function SortBox({
+  x,
+  label,
+  time,
+  fill,
+  textFill,
+}: {
+  x: number;
+  label: string;
+  time: string;
+  fill: string;
+  textFill: string;
+}) {
   return (
     <>
-      <rect x={x} y={BY} width={BW} height={BH} rx={2} style={rectStyle} />
-
-      <text x={x + BW / 2} y={BY + BH / 2}
-        textAnchor="middle" dominantBaseline="middle" style={textStyle}>
+      <rect x={x} y="16" width="68" height="48" rx="2" fill={fill} />
+      <text
+        x={x + 34}
+        y="36"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="12"
+        fontWeight="700"
+        fill={textFill}
+        style={{ fontFamily: HEADING_FONT }}
+      >
         {label}
+      </text>
+      <text
+        x={x + 34}
+        y="52"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="11"
+        fill={textFill}
+        style={{ fontFamily: BODY_FONT }}
+      >
+        {time}
       </text>
     </>
   );
 }
 
-// ── Diagram ───────────────────────────────────────────────────────────────────
-export default function TimeSequencerSortDiagram(): JSX.Element {
-  // Left: arrival order — A B C D
-  // Right: sorted order — B A C D  (0:40 < 1:05 < 1:23 < 2:01)
-  const left: Array<keyof typeof TYPES> = ["A", "B", "C", "D"];
-  const right: Array<keyof typeof TYPES> = ["B", "A", "C", "D"];
+export default function TimeSequencerSort() {
+  const { colorMode } = useColorMode();
+  const c = colorMode === "dark" ? DARK : LIGHT;
 
   return (
-    <svg
-      viewBox={`0 0 ${VB_W} ${VB_H}`}
-      role="img"
-      aria-labelledby="tssd-title tssd-desc"
-      style={{
-        width: "100%", maxWidth: 760, display: "block",
-        margin: "2rem auto", fontFamily: "inherit", overflow: "visible"
-      }}
-    >
-      <title id="tssd-title">Time Sequencer sorting diagram</title>
-      <desc id="tssd-desc">
-        Four Logic App workflows with timestamps 1:05, 0:40, 1:23 and 2:01 arrive in
-        unordered sequence. After the Time Sequencer processes them they are reordered
-        to 0:40, 1:05, 1:23, 2:01 in ascending order.
-      </desc>
-
-      {/* Left group — unsorted */}
-      {left.map((id, i) => (
-        <Block key={`L-${id}`} x={LEFT_X + i * STEP} type={TYPES[id]} label={LABELS[id]} />
-      ))}
-
-      {/* ">" separator */}
-      <text
-        x={SEP_X} y={BY + BH / 2}
-        textAnchor="middle" dominantBaseline="middle"
-        style={{ fontSize: 26, fontWeight: 700, fill: c.secondaryDark }}
+    <div style={{ maxWidth: 820, margin: "2rem auto" }}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="100%"
+        viewBox="0 0 744 80"
+        role="img"
+        aria-label="Time Sequencer sorting diagram"
       >
-        {">"}
-      </text>
-
-      {/* Right group — sorted */}
-      {right.map((id, i) => (
-        <Block key={`R-${id}`} x={RIGHT_X + i * STEP} type={TYPES[id]} label={LABELS[id]} />
-      ))}
-    </svg>
+        <SortBox x={16} label="A" time="1:05" fill={c.aBox} textFill={c.aText} />
+        <SortBox x={100} label="B" time="0:40" fill={c.bBox} textFill={c.bText} />
+        <SortBox x={184} label="C" time="1:23" fill={c.cBox} textFill={c.cText} />
+        <SortBox x={268} label="D" time="2:01" fill={c.dBox} textFill={c.dText} />
+        <text
+          x="372"
+          y="40"
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="22"
+          fill={c.separatorFill}
+          style={{ fontFamily: BODY_FONT }}
+        >
+          ›
+        </text>
+        <SortBox x={404} label="B" time="0:40" fill={c.bBox} textFill={c.bText} />
+        <SortBox x={488} label="A" time="1:05" fill={c.aBox} textFill={c.aText} />
+        <SortBox x={572} label="C" time="1:23" fill={c.cBox} textFill={c.cText} />
+        <SortBox x={656} label="D" time="2:01" fill={c.dBox} textFill={c.dText} />
+      </svg>
+    </div>
   );
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -48,6 +48,10 @@
   --ifm-navbar-search-input-color: var(--ifm-color-gray-800);
   --ifm-toc-border-color: var(--ifm-color-gray-200);
   --ifm-global-spacing: 1.5rem;
+
+  /* Typography — also consumed by inline SVG diagrams via var() */
+  --ifm-font-family-base: 'Inter', sans-serif;
+  --ifm-heading-font-family: 'Bitter', sans-serif;
   --docusaurus-details-decoration-color: var(--ifm-color-primary);
   --ifm-table-stripe-background: var(--ifm-color-secondary-lighter);
   --ifm-menu-color-background-active: var(--ifm-color-secondary-lighter);

--- a/src/data/framework.v6.bicep.parameters.json
+++ b/src/data/framework.v6.bicep.parameters.json
@@ -709,10 +709,11 @@
   {
     "name": "keyVaultName",
     "type": "string",
-    "description": "The name of the shared Azure Key Vault, used by all Framework components.",
+    "description": "The name of the shared Azure Key Vault, used by Framework components that require secrets.",
     "default": "invictus-${resourcePrefix}-vlt",
     "tags": [
-      "security"
+      "security",
+      "comp:transco"
     ]
   },
   {
@@ -961,7 +962,7 @@
   {
     "name": "aiResourcesLocation",
     "type": "string",
-    "description": "Location where the Framework deploys the Azure AI Foundray services.",
+    "description": "Location where the Framework deploys the Azure AI Foundry services.",
     "default": "swedencentral",
     "newSince": "v6.3",
     "tags": [

--- a/versioned_docs/version-v6.0.0/framework/pubsubV2.mdx
+++ b/versioned_docs/version-v6.0.0/framework/pubsubV2.mdx
@@ -8,10 +8,12 @@ import {Walkthrough, Collapsible } from "@site/src/components/Walkthrough";
 import ParameterTable from "@site/src/components/ParameterTable";
 import ComponentHeader from "@site/src/components/ComponentHeader";
 import PubSubFlowDiagram from "@site/src/components/Diagrams/PubSubFlowDiagram";
+import PubSubFlowMobileDiagram from "@site/src/components/Diagrams/PubSubFlowMobileDiagram";
 import parameters from "@site/src/data/framework.v6.bicep.parameters.json";
 import Admonition from '@theme/Admonition';
 import {faPaperPlane, faEnvelope, faCheckDouble, faLink} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import ApiPlayground from "@site/src/components/ApiPlayground";
 
 <ComponentHeader
   icon="/img/icons/pubsub.png"
@@ -29,148 +31,258 @@ Invictus provides a solution called the **PubSub**, that allows Azure Service Bu
 
 ## Component usage
 Use the PubSub component in your Logic App workflows with the following interaction:
-<PubSubFlowDiagram />
+<style>{`.pubsub-wide{display:block}.pubsub-narrow{display:none}@media(max-width:640px){.pubsub-wide{display:none}.pubsub-narrow{display:block}}`}</style>
+
+<div className="pubsub-wide">
+  <PubSubFlowDiagram />
+</div>
+<div className="pubsub-narrow">
+  <PubSubFlowMobileDiagram />
+</div>
 
 <Walkthrough>
 <Collapsible number={<FontAwesomeIcon icon={faPaperPlane} />} title="Publish single message" id="publish-single-message">
 
-The `/api/Publish` endpoint allows users to send a single message to the configured Azure Service Bus topic (default: `pubsubv2router`) where subscribers are listening to.
-
-[`Body`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.body?view=azure-dotnet#azure-messaging-servicebus-servicebusmessage-body
-[`ApplicationProperties`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.applicationproperties?view=azure-dotnet#azure-messaging-servicebus-servicebusmessage-applicationproperties
-[`MessageId`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.messageid?view=azure-dotnet#azure-messaging-servicebus-servicebusmessage-messageid
-
-| JSON property | Required (default) | Translates to `ServiceBusMessage` | Description                                                                                                                                                                                                                                                                                                                                                                                |
-| ------------- | :----------------: | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Content`     |        yes         | [`Body`]                          | Raw binary content for the message. If exceeds certain size (default `20 000 bytes`), then the component applies the claim-check pattern. The message gets sent with an empty body, and the content gets saved in Azure Blob Storage. The *Subscribe* action automatically loads the content based on specific properties from either the message itself or from Blob Storage. |
-| `Context`     |        yes         | [`ApplicationProperties`]         | User-provided properties, appended with the HTTP request headers `x-ms-client-tracking-id` and `x-ms-workflow-run-id` if present                                                                                                                                                                                                                                                           |
-| `MessageId`   |   no (new GUID)    | [`MessageId`]                     | Optional message ID for duplicate detection purposes.                                                                                                                                                                                                                                                                                                                                      |
-
-<details>
-<summary>**Full request example**</summary>
-
-```json
-// POST /api/Publish
-{
-  "Content": "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
-  "MessageId": "b0f11049-7f4d-4bae-90b2-91d93e69367d",
-  "Context": {
-    "x-applicationName": "InvoiceApp",
-    "x-batchId": "975f7ea4-6247-431b-afb6-6d27fb47516f",
-    "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0",
-    "x-correlationId": "fc13d345-ebd7-44f2-89a9-4371258c0a08"
-  }
-}
-```
-</details>
-
-The endpoint responds with `202 Accepted`, if the message gets published successfully.
-
+{/* vale off */}
+<ApiPlayground
+  method="POST"
+  path="/api/Publish"
+  description="Publishes a single message to the configured Azure Service Bus topic (default: `pubsubv2router`)."
+  request={{
+    Content: "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
+    Context: {
+      "x-applicationName": "InvoiceApp",
+      "x-batchId": "975f7ea4-6247-431b-afb6-6d27fb47516f",
+      "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0",
+      "x-correlationId": "fc13d345-ebd7-44f2-89a9-4371258c0a08"
+    },
+  }}
+  parameters={[
+    {
+      name: "Content",
+      type: "string",
+      required: true,
+      description: "Raw binary content for the message (translates to [`ServiceBusMessage.Body`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.body?view=azure-dotnet#azure-messaging-servicebus-servicebusmessage-body)). If exceeds certain size (default `20 000 bytes`), then the component applies the claim-check pattern. The message gets sent with an empty body, and the content gets saved in Azure Blob Storage. The *Subscribe* action automatically loads the content based on specific properties from either the message itself or from Blob Storage."
+    },
+    {
+      name: "Context",
+      type: "object",
+      required: true,
+      description: "User-provided properties (translates to [`ServiceBusMessage.ApplicationProperties`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.applicationproperties?view=azure-dotnet#azure-messaging-servicebus-servicebusmessage-applicationproperties)), appended with the HTTP request headers `x-ms-client-tracking-id` and `x-ms-workflow-run-id` if present"
+    },
+    {
+      name: "MessageId",
+      type: "string",
+      required: false,
+      description: "Optional message ID (translates to [`ServiceBusMessage.MessageId`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.messageid?view=azure-dotnet#azure-messaging-servicebus-servicebusmessage-messageid)) for duplicate detection purposes."
+    }
+  ]}
+  responses={[
+    {
+      status: 200,
+      label: "OK",
+      body: "Message published successfully."
+    },
+    {
+      status: 400,
+      label: "Invalid request",
+      description: "The request body is invalid or missing required properties.",
+      body: "Failed to publish message because the request body is invalid or missing required properties."
+    },
+    {
+      status: 400,
+      label: "Send failure",
+      description: "The message failed to send to the Azure Service Bus topic due to a Service Bus-specific error, serialization or the when the claim-check failed.",
+      body: "Failed to publish message due to an unexpected Azure Service Bus error, please check the logs for more information."
+    },
+    {
+      status: 500,
+      label: "Internal server error",
+      description: "An unexpected error occurred while processing the request.",
+      body: "Failed to publish message due to an unexpected error, please check the logs for more information."
+    }
+  ]}
+/>
+{/* vale on */}
 
 </Collapsible>
 
 <Collapsible number={<FontAwesomeIcon icon={faEnvelope} />} title="Subscribe for messages" id="subscribe-for-messages">
-The `/api/Subscribe` endpoint allows users to periodically ask for any available published messages on the configured Azure Service Bus topic (default: `pubsubv2router`).
 
-[`SubscriptionName`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.administration.createsubscriptionoptions.subscriptionname?view=azure-dotnet#azure-messaging-servicebus-administration-createsubscriptionoptions-subscriptionname
-[`SqlExpression`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.administration.sqlrulefilter.sqlexpression?view=azure-dotnet#azure-messaging-servicebus-administration-sqlrulefilter-sqlexpression
-[`Rule`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.administration.ruleproperties.name?view=azure-dotnet#azure-messaging-servicebus-administration-ruleproperties-name
-[`BatchSize`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceiver.receivemessagesasync?view=azure-dotnet#azure-messaging-servicebus-servicebusreceiver-receivemessagesasync(system-int32-system-nullable((system-timespan))-system-threading-cancellationtoken)
-[`MaxWaitTime`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceiver.receivemessagesasync?view=azure-dotnet#azure-messaging-servicebus-servicebusreceiver-receivemessagesasync(system-int32-system-nullable((system-timespan))-system-threading-cancellationtoken)
-[`ReceiveAndDelete`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceivemode?view=azure-dotnet
-[`PeekLock`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceivemode?view=azure-dotnet
-
-| JSON property            |       Required (default)       | Translates to Service Bus           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ------------------------ | :----------------------------: | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Subscription`           |              yes               | [`SubscriptionName`]                | Name of Azure Service Bus topic subscription, gets created if not exists. (Name is also used as name of the [`Rule`].)                                                                                                                                                                                                                                                                                                                                            |
-| `Filter`                 | no (subscribe on all messages) | [`SqlExpression`]                   | Optional SQL expression that acts as a filter rule for which messages to subscribe on.                                                                                                                                                                                                                                                                                                                                                                            |
-| `BatchSize`              |            no (10)             | [`BatchSize`]                       | Maximum messages to receive during this single call.                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `TimeoutMilliseconds`    |           no (1min)            | [`MaxWaitTime`]                     | Maximum time to wait for a message before responding with an empty set of messages.                                                                                                                                                                                                                                                                                                                                                                               |
-| `ShouldDeleteOnReceive`  |          no (`false`)          | [`ReceiveAndDelete`]                | `false` (default) means [`PeekLock`], `true` means receiving messages with [`ReceiveAndDelete`]. <br/><br/> <Admonition type="warning">In some rare cases, the use of `ShouldDeleteOnReceive=true` could cause the receiver to lose messages. For example when an error occurs on during receiving and one loses the sequence number, or when cancelled/scaled-down happens at the exact moment the client receives the message (and doesn't exist on the topic subscription anymore).</Admonition> |
-| `SkipSubscriptionUpsert` |          no (`false`)          | create/update subscription and rule | `true` means there should already be a topic subscription available, `false` (default) means that a subscription will be created with the provided `Filter`.                                                                                                                                                                                                                                                                                                      |
-
-:::tip
-One can also use the HTTP request query parameters instead of the request body to `POST` to the `/api/Subscribe` endpoint: `/api/Subscribe?Subscription=orderProcessor`.
-:::
-
-<details>
-<summary>**Full request example**</summary>
-
-```json
-// POST -> /api/Subscribe
-{
-    "Subscription": "orderProcessor",
-    "Filter": "sys.label = 'OrderCreated'",
-    "BatchSize": 11,
-    "TimeoutMilliseconds": 30000,
-    "ShouldDeleteOnReceive": false,
-    "SkipSubscriptionUpsert": false
-}
-```
-</details>
-
-<details>
-<summary>**Full response example**</summary>
-
-```json
-// 200 OK <- /api/Subscribe
-[
+{/* vale off */}
+<ApiPlayground
+  method="POST"
+  path="/api/Subscribe"
+  description="Subscribes to messages on the configured Azure Service Bus topic (default: `pubsubv2router`)."
+  parametersTitle="Body/Query parameters"
+  request={{
+    Subscription: "subscriptionName",
+    Filter: "x-applicationName = 'InvoiceApp'"
+  }}
+  parameters={[
     {
-        "subscription": "orderProcessor",
-        "content": "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
-        "context": {
+      name: "Subscription",
+      type: "string",
+      required: true,
+      description: "Name of Azure Service Bus topic subscription (translates to [`CreateSubscriptionOptions.SubscriptionName`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.administration.createsubscriptionoptions.subscriptionname?view=azure-dotnet#azure-messaging-servicebus-administration-createsubscriptionoptions-subscriptionname)), creates if not exists. (Name is also used as name of the [rule](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.administration.ruleproperties.name?view=azure-dotnet#azure-messaging-servicebus-administration-ruleproperties-name).)"
+    },
+    {
+      name: "Filter",
+      type: "string",
+      required: false,
+      description: "Optional SQL expression (translates to [`SqlExpression`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.administration.sqlrulefilter.sqlexpression?view=azure-dotnet#azure-messaging-servicebus-administration-sqlrulefilter-sqlexpression)) that acts as a filter rule for which messages to subscribe on."
+    },
+    {
+      name: "BatchSize",
+      type: "integer",
+      required: false,
+      description: "Maximum messages to receive during this single call. Translates to [`BatchSize`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceiver.receivemessagesasync?view=azure-dotnet#azure-messaging-servicebus-servicebusreceiver-receivemessagesasync(system-int32-system-nullable((system-timespan))-system-threading-cancellationtoken))."
+    },
+    {
+      name: "TimeoutMilliseconds",
+      type: "integer",
+      required: false,
+      description: "Maximum time to wait for a message before responding with an empty set of messages. Translates to [`MaxWaitTime`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceiver.receivemessagesasync?view=azure-dotnet#azure-messaging-servicebus-servicebusreceiver-receivemessagesasync(system-int32-system-nullable((system-timespan))-system-threading-cancellationtoken))"
+    },
+    {
+      name: "ShouldDeleteOnReceive",
+      type: "boolean",
+      required: false,
+      description: (<>
+        <code>false</code> (default) means <a href="https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock" target="_blank" rel="noopener noreferrer"><code>PeekLock</code></a>, <code>true</code> means receiving messages with <a href="https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#receiveanddelete" target="_blank" rel="noopener noreferrer"><code>ReceiveAndDelete</code></a>.
+        <Admonition type="warning">
+          In some rare cases, the use of <code>ShouldDeleteOnReceive=true</code> could cause the receiver to lose messages — for example when an error occurs during receiving and the sequence number is lost, or when a scale-down happens at the exact moment the client receives the message.
+        </Admonition>
+      </>)
+    },
+    {
+      name: "SkipSubscriptionUpsert",
+      type: "boolean",
+      required: false,
+      description: "`true` means there should already be a topic subscription available, `false` (default) means that a subscription will be created with the provided `Filter`."
+    }
+  ]}
+  responses={[
+    {
+      status: 200,
+      label: "OK",
+      description: "Returns a list of messages received from the Azure Service Bus topic subscription.",
+      body: [
+        {
+          subscription: "orderProcessor",
+          content: "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
+          context: {
             "x-applicationName": "InvoiceApp",
             "x-batchId": "975f7ea4-6247-431b-afb6-6d27fb47516f",
             "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0",
             "x-correlationId": "fc13d345-ebd7-44f2-89a9-4371258c0a08",
             "x-ms-client-tracking-id": "test",
             "Diagnostic-Id": "00-0cc7ed09eeaa51b0e835d90890aefb60-b0a02deac9f6fe6d-00"
-        },
-        "sequenceNumber": 99
+          },
+          sequenceNumber: 99
+        }
+      ]
     },
-    ...
-]
-```
-</details>
-
-:::warning[internal workaround]
-Because messages can be 'acknowledged' separately from the receive location by 'subscription', the message is internally [deferred](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-deferral). This is due to restrictions in the Azure SDK which impose that the same receiver must both receive and settle message. Deferring a message doesn't have this limitation.
-:::
+    {
+      status: 400,
+      label: "Invalid request",
+      description: "The request body is invalid or missing required properties.",
+      body: "Failed to subscribe for messages because the request body is invalid or missing required properties."
+    },
+    {
+      status: 400,
+      label: "Subscription failure",
+      description: "The subscription retrieval failed due to a Service Bus-specific error.",
+      body: "Failed to subscribe for messages due to an unexpected Azure Service Bus error, please see the logs for more information."
+    },
+    {
+      status: 500,
+      label: "Internal server error",
+      description: "An unexpected error occurred while processing the request.",
+      body: "Failed to subscribe for messages due to an unexpected error, please check the logs for more information."
+    }
+  ]}
+/>
+{/* vale on */}
 
 </Collapsible>
 
 <Collapsible number={<FontAwesomeIcon icon={faCheckDouble} />} title="Acknowledge message" id="acknowledge-message">
 
-The `/api/Acknowledge` endpoint allows users to 'settle' a received message via the `/api/Subscribe` endpoint. This requires the **sequence number** of the message.
+:::warning[internal workaround]
+Because messages can be 'acknowledged' separately from the receive location by 'subscription', the message is internally [deferred](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-deferral). This is due to restrictions in the Azure SDK which impose that the same receiver must both receive and settle message. Deferring a message doesn't have this limitation.
+:::
 
-[`CreateReceiver`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusclient.createreceiver?view=azure-dotnet#azure-messaging-servicebus-servicebusclient-createreceiver(system-string-system-string)
-[Message settlement]: https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement
-[`ReceiveDeferredMessage`]: https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceiver.receivedeferredmessageasync?view=azure-dotnet
-[`MessageNotFound`]: https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-exceptions-latest
-
-| JSON Property             | Required (default) | Translates to Service Bus  | Description                                                                                                                                                                                      |
-| ------------------------- | :----------------: | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Subscription`            |        yes         | [`CreateReceiver`]         | Name of Azure Service Bus topic subscription to receive the deferred message on (See **internal workaround** on `/api/Subscribe`)                                    |
-| `SequenceNumber`          |        yes         | [`ReceiveDeferredMessage`] | Unique number assigned by Service Bus, received by the `/api/Subscribe` response.                                                                                                                        |      
-| `AcknowledgementType`     |  no (`Complete`)   | [Message settlement]       | Type of acknowledge action to take on the message: <ul><li>`Complete`</li><li>`Abandon`</li><li>`Defer`</li><li>`DeadLetter`</li></ul>                                                           |
-| `IgnoreNotFoundException` |    no (`false`)    | [`MessageNotFound`]        | `true` means that `MessageNotFound` Service Bus failures during lookup of the message by its `SequenceNumber` will result in `202 Accepted`; `false` means a `400 BadRequest` will be responded. |
-
-<details>
-<summary>**Full request example**</summary>
-
-```json
-// POST /api/Acknowledge
-{
-    "Subscription": "subscriptionName",
-    "AcknowledgementType":"Complete",
-    "SequenceNumber": 99,
-    "IgnoreNotFoundException": false,
-}
-```
-</details>
+{/* vale off */}
+<ApiPlayground
+  method="POST"
+  path="/api/Acknowledge"
+  description="Acknowledges a message received via the `/api/Subscribe` endpoint. This requires the `SequenceNumber` of the message."
+  request={{
+    Subscription: "subscriptionName",
+    AcknowledgementType: "Complete",
+    SequenceNumber: 99,
+    IgnoreNotFoundException: false
+  }}
+  parameters={[
+    {
+      name: "Subscription",
+      type: "string",
+      required: true,
+      description: "Name of Azure Service Bus topic subscription (translates to [`CreateReceiver`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusclient.createreceiver?view=azure-dotnet#azure-messaging-servicebus-servicebusclient-createreceiver(system-string-system-string))) to receive the deferred message on (See **internal workaround** on `/api/Subscribe`)."
+    },
+    {
+      name: "SequenceNumber",
+      type: "integer",
+      required: true,
+      description: "Unique number assigned by Service Bus (translates to [`ReceiveDeferredMessage`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceiver.receivedeferredmessageasync?view=azure-dotnet)), received by the `/api/Subscribe` response."
+    },
+    {
+      name: "AcknowledgementType",
+      type: "string",
+      required: false,
+      description: <>
+        Type of acknowledge action to take on the message (translates to <a href="https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement" target="_blank" rel="noopener noreferrer">Messages settlement</a>). Default is <code>Complete</code>. Options are:<ul><li><code>Complete</code></li><li><code>Abandon</code></li><li><code>Defer</code></li><li><code>DeadLetter</code></li></ul>
+      </>
+    },
+    {
+      name: "IgnoreNotFoundException",
+      type: "boolean",
+      required: false,
+      description: "`true` means that [`MessageNotFound`](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-exceptions-latest) Service Bus failures during lookup of the message by its `SequenceNumber` will result in `202 Accepted`; `false` means a `400 BadRequest` will be responded. Default is `false`."
+    }
+  ]}
+  responses={[
+    {
+      status: 200,
+      label: "OK",
+      description: "Message acknowledged successfully.",
+      body: "Message acknowledged successfully."
+    },
+    {
+      status: 400,
+      label: "Invalid request",
+      description: "The request body is invalid or missing required properties.",
+      body: "Failed to acknowledge message because the request body is invalid or missing required properties."
+    },
+    {
+      status: 400,
+      label: "Acknowledge failure",
+      description: "The message acknowledge failed due to a Service Bus-specific error.",
+      body: "Failed to acknowledge message due to an unexpected Azure Service Bus error, please see the logs for more information."
+    },
+    {
+      status: 500,
+      label: "Internal server error",
+      description: "An unexpected error occurred while processing the request.",
+      body: "Failed to acknowledge message due to an unexpected error, please check the logs for more information."
+    }
+  ]}
+/>
+{/* vale on */}
 
 </Collapsible>
 </Walkthrough>
 
-## Related Bicep template parameters
+### Related Bicep template parameters
 <ParameterTable parameters={parameters} fixedTags={["comp:pubsub"]} />

--- a/versioned_docs/version-v6.0.0/framework/regextranslation.mdx
+++ b/versioned_docs/version-v6.0.0/framework/regextranslation.mdx
@@ -7,6 +7,11 @@ hide_title: true
 import ParameterTable from "@site/src/components/ParameterTable";
 import parameters from "@site/src/data/framework.v6.bicep.parameters.json"; 
 import ComponentHeader from "@site/src/components/ComponentHeader";
+import { faLanguage, faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ComponentFlowDiagram from "@site/src/components/Diagrams/ComponentFlowDiagram";
+import ApiPlayground from "@site/src/components/ApiPlayground";
+import {Walkthrough, Collapsible} from "@site/src/components/Walkthrough";
 
 <ComponentHeader
   icon="/img/icons/regex-translator.png"
@@ -17,50 +22,99 @@ import ComponentHeader from "@site/src/components/ComponentHeader";
 At the time of writing, there is no built-in Logic App functionality available to run regular expression replacements without using `inline code`. The Invictus **Regex Translation** Framework component fills this missing link. It provides a HTTP-endpoint to run regular expression replacements. All available translations are available in an Azure Table Storage.
 :::
 
-## Regex translate user content
-The **Regex Translation** component has a single endpoint available: `/api/RegexTranslation`. Given an user content and matched stored (Azure Table Storage, default: `RegexTranslator` table) regular expression translation, the endpoint responds with the translated content.
+## Component usage
+The **Regex Translator** component has a single endpoint available.
+Given an user content and matched stored (Azure Table Storage, default: `RegexTranslator` table) regular expression translation, the endpoint responds with the translated content.
 
-| JSON property | Required | Description                                                                                                                                                                                           |
-| ------------- | :------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Content`     |   yes    | User content to translate.                                                                                                                                                                  |
-| `MatchKey`    |   yes    | Set of 'keys' that translates to [Azure Table Storage partition keys](https://learn.microsoft.com/en-us/rest/api/storageservices/designing-a-scalable-partitioning-strategy-for-azure-table-storage). |
+{/* vale off */}
+<ComponentFlowDiagram
+  name="Regex Translator"
+  tagline="Pattern-based content translation"
+  icon={faLanguage}
+  rows={[
+    {
+      input: "Content+Keys",
+      opTitle: "Regex Translator",
+      opSubtitle: "Pattern lookup & replace",
+      output: "Translated",
+      storageLabel: "Azure Table Storage",
+    },
+  ]}
+/>
+{/* vale on */}
 
-<details>
-<summary>**Full request example**</summary>
+<Walkthrough>
+<Collapsible number={<FontAwesomeIcon icon={faLanguage} />} title="Translate user content via regular expression replacement">
 
-```json
-// POST /api/RegexTranslation
-{
-  "Content": "The provided host name 'website.com' could not be resolved",
-  "MatchKey": ["OrderService", "InvoiceService"]
-}
-```
-</details>
+{/* vale off */}
+<ApiPlayground
+  method="POST"
+  path="/api/RegexTranslation"
+  description="Translates user content via regular expression replacement, using stored translations in Azure Table Storage."
+  request={{
+    content: "The provided host name 'website.com' could not be resolved",
+    matchKey: ["OrderService", "InvoiceService"]
+  }}
+  parameters={[
+    {
+      name: "content",
+      type: "string",
+      required: true,
+      description: "User content to translate."
+    },
+    {
+      name: "matchKey",
+      type: "array",
+      required: true,
+      description: "Set of 'keys' that translates to Azure Table Storage partition keys."
+    }
+  ]}
+  responses={[
+    {
+      status: 200,
+      label: "Translated",
+      description: "The user content was translated via a stored regular expression translation.",
+      body: {
+        content: "System could not reach endpoint 'website.com' as it is not available, please contact John to follow-up.",
+        isTranslated: true,
+        rowKey: "2f71ec69-1fff-4b80-9ae1-947a58e4a039"
+      }
+    },
+    {
+      status: 200,
+      label: "Not Translated",
+      description: "The user content was not translated, no stored regular expression translation was found.",
+      body: {
+        content: "The provided host name 'website.com' could not be resolved",
+        isTranslated: false,
+        rowKey: ""
+      }
+    },
+    {
+      status: 400,
+      label: "Bad Request",
+      description: "The request was malformed or missing required properties.",
+      body: "Failed to translate user content via regular expression replacement, request was malformed or missing required properties."
+    },
+    {
+      status: 404,
+      label: "Not Found",
+      description: "No stored regular expression translations were found.",
+      body: "Failed to translate user content via regular expression replacement, no stored translations were found."
+    },
+    {
+      status: 500,
+      label: "Internal Server Error",
+      description: "An unexpected error occurred during the translation process.",
+      body: "An unexpected error occurred during the translation process."
+    }
+  ]}/>
+{/* vale off */}
 
-<details>
-<summary>**Full response example**</summary>
+</Collapsible>
 
-```json
-// Found stored translation:
-// 200 OK <- /api/RegexTranslation
-{
-  "Content": "System could not reach endpoint 'website.com' as it is not available, please contact John to follow-up.",
-  "IsTranslated": true,
-  "RowKey": "2f71ec69-1fff-4b80-9ae1-947a58e4a039"
-}
+<Collapsible number={<FontAwesomeIcon icon={faFloppyDisk} />} title="Store regular expression translations">
 
-// Did not found stored translation:
-// 200 OK <- /api/RegexTranslation
-{
-  "Content": "The provided host name 'website.com' could not be resolved",
-  "IsTranslated": false,
-  "RowKey": ""
-}
-```
-
-</details>
-
-## Stored regular expression translations
 Store available regular expression translations in the Azure Table Storage table called `RegexTranslator` (Invictus creates this table automatically). Each stored entity should have following custom properties:
 
 [named groups]: https://learn.microsoft.com/en-us/dotnet/standard/base-types/grouping-constructs-in-regular-expressions#named-matched-subexpressions
@@ -86,5 +140,9 @@ Store available regular expression translations in the Azure Table Storage table
 * **Single match**: the user `Content` can only match a single stored translation - the component picks the first match.
 * **No pastes**: the `OutputPattern` doesn't necessarily *have* to contain `{group-name}` occurrences, it can only contain text.
 
-## Related Bicep template parameters
+
+</Collapsible>
+</Walkthrough>
+
+### Related Bicep template parameters
 <ParameterTable parameters={parameters} fixedTags={["comp:regex-translator"]} />

--- a/versioned_docs/version-v6.0.0/framework/sequencecontroller.mdx
+++ b/versioned_docs/version-v6.0.0/framework/sequencecontroller.mdx
@@ -7,7 +7,7 @@ hide_title: true
 import ParameterTable from "@site/src/components/ParameterTable";
 import parameters from "@site/src/data/framework.v6.bicep.parameters.json"; 
 import Admonition from '@theme/Admonition';
-import {faCircleDown, faHourglassHalf, faCheckDouble, faEarthEurope, faLink, faBoltLightning, faRotate} from "@fortawesome/free-solid-svg-icons";
+import {faHashtag, faHourglassHalf, faCheckDouble, faEarthEurope, faLink, faBoltLightning, faRotate} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import ComponentHeader from "@site/src/components/ComponentHeader";
 import SequenceControllerFlowDiagram from "@site/src/components/Diagrams/SequenceControllerFlowDiagram";
@@ -25,8 +25,11 @@ import {NewSinceBadge} from "@site/src/components/Badges";
 :::note[motivation]
 Some dependent external systems can't handle parallel message processing or requires a certain order of messages. Sending messages serially (for example, by setting the concurrency on a Logic App to `1`) can be a solution, at the cost of a big performance impact.
 
-> <FontAwesomeIcon icon={faEarthEurope} /> **A customer story from the trenches** <br/>
-> *A downstream application can't handle calls at the same time for the same order ID, by using the **Sequence Controller** we guarantee a single call per order ID (by using the order ID in the `sequenceName`) and we don't have the use the concurrency option for the Logic App which would dramatically slow down the processing for all messages.*
+<Walkthrough>
+<Collapsible number={<FontAwesomeIcon icon={faEarthEurope} />} title="A customer story from the trenches" >
+*A downstream application can't handle calls at the same time for the same order ID, by using the **Sequence Controller** we guarantee a single call per order ID (by using the order ID in the `sequenceName`) and we don't have the use the concurrency option for the Logic App which would dramatically slow down the processing for all messages.*
+</Collapsible>
+</Walkthrough>
 
 The Invictus Framework provides a **Sequence Controller** component that allows you to process Logic App workflow runs in a specified order. Even parallel triggered workflows won't overblown the external dependency with messages.
 
@@ -44,7 +47,7 @@ The component processes workflows in sequence after the **Wait**. The place betw
 If workflow 1 gets triggered before workflow 2, the second workflow waits for the first workflow.
 
 <Walkthrough>
-<Collapsible number={<FontAwesomeIcon icon={faCircleDown} />} title="Get sequence number" >
+<Collapsible number={<FontAwesomeIcon icon={faHashtag} />} title="Get sequence number" >
 
 {/* vale off */}
 <ApiPlayground
@@ -261,13 +264,16 @@ If workflow 1 gets triggered before workflow 2, the second workflow waits for th
 
 <Collapsible number={<FontAwesomeIcon icon={faRotate} />} title="Reset sequence (only for advanced usages)" >
 
+:::danger[Resetting sequences]
+This action <strong>SHOULD NOT</strong> be part of any Logic App workflow as resetting sequences in the middle of processing will result in indefinitely 'hanging' workflow runs.
+:::
+
 {/* vale off */}
 <ApiPlayground
   method="POST"
   path="/api/ResetSequence"
   description={<>
     Resets the sequence for a given sequence name, allowing for reuse or cleanup of old sequences.
-    <Admonition type="danger" title="Resetting sequences">This action <strong>SHOULD NOT</strong> be part of any Logic App workflow as resetting sequences in the middle of processing will result in indefinitely 'hanging' workflow runs.</Admonition>
   </>}
   parameters={[
     {

--- a/versioned_docs/version-v6.0.0/framework/transcoV2.mdx
+++ b/versioned_docs/version-v6.0.0/framework/transcoV2.mdx
@@ -10,6 +10,9 @@ import ParameterTable from "@site/src/components/ParameterTable";
 import parameters from "@site/src/data/framework.v6.bicep.parameters.json";
 import ComponentHeader from "@site/src/components/ComponentHeader";
 import { Walkthrough, Collapsible } from "@site/src/components/Walkthrough";
+import ComponentFlowDiagram from "@site/src/components/Diagrams/ComponentFlowDiagram";
+import ApiPlayground from "@site/src/components/ApiPlayground";
+import { faGear } from "@fortawesome/free-solid-svg-icons";
 
 <ComponentHeader
   icon="/img/icons/transco.png"
@@ -20,7 +23,49 @@ import { Walkthrough, Collapsible } from "@site/src/components/Walkthrough";
 :::note[motivation]
 Integration scenarios often need to 'promote' or 'enrich' messages/data from either internal or external data sources. Codit is a long-term implementer of something called 'Transco', which was originally a Microsoft BizTalk component. Now, modern Azure Logic Apps integration benefits from this behavior.
 
-Invictus provides a Transco component to
+Invictus provides a Transco component to promote properties from a SQL database or to transform XML content via XSLT transformations. The component can also promote values to the context of the response.
+:::
+
+## Component usage
+The Transco component has endpoints available for XML or JSON content.
+Given a stored Transco configuration file, the component promotes values from a client's SQL database or transforms XML content via a stored XSLT file.
+
+{/* vale off */}
+<ComponentFlowDiagram
+  name="Transco"
+  tagline="Property Promotion & Transformation"
+  icon={faGear}
+  iconEvenOdd
+  rows={[
+    {
+      input: "XML or JSON",
+      opTitle: "SQL Promote",
+      opSubtitle: "Promote via client's database",
+      output: "Enriched",
+      storageLabel: "Client's DB + Azure Blob Storage",
+    },
+    {
+      input: "XML",
+      opTitle: "XSLT Transform",
+      opSubtitle: "Transform via XSLT",
+      output: "Transformed",
+      storageLabel: "Azure Blob Storage",
+    },
+    {
+      input: "Parameters",
+      opTitle: "Basic Promote",
+      opSubtitle: "Promote to context",
+      output: "Context"
+    },
+  ]}
+/>
+{/* vale on */}
+
+{/* <Tabs>
+<TabItem value="xml-json" label="XML/JSON">
+
+
+
 <Walkthrough>
 <Collapsible number="SQL" title="Promote client requests with client's database">
 
@@ -37,57 +82,101 @@ The component applies the transformation to the request content and promotes the
 
 </Collapsible>
 </Walkthrough>
-:::
 
-## Available endpoints
-* `/api/TranscoXML`: uses XML content and a Transco configuration file to list the instructions necessary to promote values or to transform the content via an XSLT file.
-
-* `/api/TranscoJson`: uses JSON content and a Transco configuration file to list the instructions necessary to promote values. The component can't perform transformations on JSON content.
-
-* `/api/MatrixBasicPromote`: accepts a list of parameters and promotes them to the `Context` in the response.
+</TabItem>
+</Tabs> */}
 
 <Tabs groupId="transco-endpoints">
 <TabItem value="json-xml" label="XML/JSON">
 
-The Transco request requires following values:
-* XML/JSON content in Base64 format;
-* Context as key-value pair list;
-* Name of Transco config file in an Azure Blob Storage container.
-
-<details>
-<summary>**Full request body JSON example**</summary>
-
-```json
-// POST /api/TranscoXML
-// POST /api/TranscoJson
-{
-  "Content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTE2Ij8+PHJvb3Q+PG5hbWUgc3RhdHVzPSJNZW1iZXIiPkpvaG4gRG9lPC9uYW1lPjwvcm9vdD4=",
-  "Context": {
-    "CustomerActive": "true" 
-  }, 
-  "TranscoConfig": "docs_config.json"
-}
-```
-</details>
-
-<details>
-<summary>**Full response body JSON example**</summary>
-
-```json
-// 200 OK <- /api/TranscoXML
-// 200 OK <- /api/TranscoJson
-{
-  "Content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTE2Ij8+PE1lbWJlcj5Kb2huIERvZTwvTWVtYmVyPg==",
-  "Context": {
-    "CustomerActive": "true"
-  },
-  "TranscoConfig": "docs_config.json"
-}
-```
-</details>
+{/* vale off */}
+<ApiPlayground
+  method="POST"
+  path="/api/TranscoXML or /api/TranscoJson"
+  description="Promotes values from a SQL database or transforms XML content via a stored XSLT file, based on a stored Transco configuration file."
+  request={{
+    content: "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTE2Ij8+PHJvb3Q+PG5hbWUgc3RhdHVzPSJNZW1iZXIiPkpvaG4gRG9lPC9uYW1lPjwvcm9vdD4=",
+    transcoConfig: "docs_config.json",
+    context: {
+      customerActive: true
+    }
+  }}
+  parameters={[
+    {
+      name: "content",
+      type: "string",
+      required: true,
+      description: "The input XML or JSON content as a Base64-encoded string."
+    },
+    {
+      name: "transcoConfig",
+      type: "string",
+      required: true,
+      description: "The filename of the Transco configuration file, stored in the internal blob storage container (for example `docs_config.json`)."
+    },
+    {
+      name: "context",
+      type: "object",
+      required: false,
+      description: "The dictionary providing context to the conversion, gets copied 1:1 to the response."
+    }
+  ]}
+  responses={[
+    {
+      status: 200,
+      label: "Success",
+      description: "The Transco component successfully promoted values or transformed the content.",
+      body: {
+        content: "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTE2Ij8+PE1lbWJlcj5Kb2huIERvZTwvTWVtYmVyPg==",
+        transcoConfig: "docs_config.json",
+        context: {
+          customerActive: true
+        }
+      }
+    },
+    {
+      status: 400,
+      label: "Invalid request",
+      description: "The request was invalid or missing required parameters.",
+      body: "Failed to transco transform content because the request body did not contain a valid JSON with the required fields."
+    },
+    {
+      status: 404,
+      label: "Transco config not found",
+      description: "The specified Transco configuration file could not be found.",
+      body: "Failed to transco transform content because the Transco configuration file 'docs_config.json' was not found in the backend storage."
+    },
+    {
+      status: 404,
+      label: "XSLT not found",
+      description: "The specified XSLT file could not be found.",
+      body: "Failed to transco transform content because the XSLT file 'docs_transform.xsl' was not found in the backend storage."
+    },
+    {
+      status: 424,
+      label: "SQL query failed",
+      description: "The SQL query execution failed.",
+      body: "Failed to transco transform content because the SQL query execution failed, please see the logs for more details."
+    },
+    {
+      status: 500,
+      label: "Internal Server Error",
+      description: "An error occurred while processing the request.",
+      body: "Failed to transco transform content because an unexpected error occurred, please see the logs for more details."
+    },
+    {
+      status: 501,
+      label: "XSLT result not XML",
+      description: "The result of the XSLT transformation was not a valid XML document.",
+      body: "Failed to transco transform content because the result of the XSLT transformation was not a valid XML document."
+    }
+  ]}
+/>
+{/* vale on */}
 
 ## Transco configuration file
 The component requires a JSON Transco configuration file to describe the instructions to perform. Execution of instructions happens in the order in which they appear.
+Store the configuration file in the Azure Storage Account in the `Transcov2configstore` container, in the `/Configs` folder.
 
 <Tabs groupId="Transco-instructions">
 <TabItem value="sql-command" label="SQL Commands" default>
@@ -199,28 +288,49 @@ You can also promote the SQL query result to the `Context` instead of the `Conte
 
 <TabItem value="xml-transformation" label="XML Transformation">
 
-The Transco component can execute XSLT transformations on XML content. You must specify the name of the XSLT file in the storage account. 
+<Walkthrough>
+<Collapsible title="Specify name of the XSLT transformation file">
 
-Specify required assemblies and dependencies used by the transformation, while the respective DLL files are to be in the storage account.
+The Transco component can execute XSLT transformations on XML content. Specify the name of the XSLT file as an instruction in the Transco configuration file.
+Store the XSLT file in the Azure Storage Account in the `Transcov2configstore` container, in the `/XSLTs` folder.
 
-This instruction is only available when calling the `/TranscoXML` endpoint.
 ```json
 {
-  "xsltTransform": [Name of XSLT file],
-  "extensions": [
+  "instructions": [
     {
-      "namespace": [Assembly namespace],
-      "assemblyName": [Assembly name],
-      "className": [Assembly class name],
-      "dependencies": [
-        "[DLL dependency file name]",
-        "[DLL dependency file name]"
+      "xsltTransform": "[Name of XSLT file]"
+    }
+  ]
+}
+```
+</Collapsible>
+<Collapsible title="Specify required assemblies and dependencies">
+When the XSLT transformation requires custom extension functions, specify them as required assemblies and dependencies in the Transco configuration file.
+Store the assembly and dependency DLL files in the Azure Storage Account in the `Transcov2configstore` container, in the `/Assemblies` folder.
+
+```json
+{
+  "instructions": [
+    {
+      "xsltTransform": "[Name of XSLT file]",
+      "extensions": [
+        {
+          "namespace": "[Assembly namespace]",
+          "assemblyName": "[Assembly name]",
+          "className": "[Assembly class name]",
+          "dependencies": [
+            "[DLL dependency file name]",
+            "[DLL dependency file name]"
+          ]
+        }
       ]
     }
   ]
 }
 ```
 
+</Collapsible>
+</Walkthrough>
 </TabItem>
 </Tabs>
 
@@ -231,49 +341,49 @@ This instruction is only available when calling the `/TranscoXML` endpoint.
 {
   "instructions": [
     {
-      "scopePath": [XPath/JPath of content scope],
+      "scopePath": "[XPath/JPath of content scope]",
       "namespaces": [
         {
-          "namespace": [XML Namespace],
-          "prefix": [XML Namespace prefix]
+          "namespace": "[XML Namespace]",
+          "prefix": "[XML Namespace prefix]"
         }
       ],
       "command": {
-        "databaseConnectionString":[Raw connection string to DB],
-        "databaseKeyVaultName": [Name of DB connection string secret in Key Vault],
-        "commandValue": [SQL query to be executed],
-        "isMandatory": [If true, will throw error when result is null],
-        "columnName": [Obtain value from specified column if query returns more than one field. If empty, use value from first column],
-        "defaultValue": [Default value of result],
+        "databaseConnectionString":"[Raw connection string to DB]",
+        "databaseKeyVaultName": "[Name of DB connection string secret in Key Vault]",
+        "commandValue": "[SQL query to be executed]",
+        "isMandatory": "[If true, will throw error when result is null]",
+        "columnName": "[Obtain value from specified column if query returns more than one field. If empty, use value from first column]",
+        "defaultValue": "[Default value of result]",
         "parameters": [
           {
-            "paramName": [Name of param in query],
-            "value": [Type dependent. XPath or JPath if valueType = "path"],
-            "type": [SQL DB type. See: https://learn.microsoft.com/en-us/dotnet/api/system.data.sqldbtype],
-            "valueType": ["path" or "fixedValue" or "context"]
+            "paramName": "[Name of param in query]",
+            "value": "[Type dependent. XPath or JPath if valueType = 'path']",
+            "type": "[SQL DB type. See: https://learn.microsoft.com/en-us/dotnet/api/system.data.sqldbtype]",
+            "valueType": "['path' or 'fixedValue' or 'context']"
           },
           {
-            "paramName": [Name of param in query],
-            "value": [Type dependent. Any string value if valueType = "fixedValue"],
-            "type": [SQL DB type. See: https://learn.microsoft.com/en-us/dotnet/api/system.data.sqldbtype],
-            "valueType": ["path" or "fixedValue" or "context"]
+            "paramName": "[Name of param in query]",
+            "value": "[Type dependent. Any string value if valueType = 'fixedValue']",
+            "type": "[SQL DB type. See: https://learn.microsoft.com/en-us/dotnet/api/system.data.sqldbtype]",
+            "valueType": "['path' or 'fixedValue' or 'context']"
           }
         ],
-        "destination": [XPath/JPath of the results destination, or Context key if "promoteToContext=true"],
-        "promoteToContext": [If true, the component saves the SQL query result to Context with "destination" as key],
+        "destination": "[XPath/JPath of the results destination, or Context key if 'promoteToContext=true']",
+        "promoteToContext": "[If true, the component saves the SQL query result to Context with 'destination' as key]",
         "cache": {
-          "useCaching": [If true, caches the SQL query result],
-          "cachingTimeout": [Cache timeout time span]
+          "useCaching": "[If true, caches the SQL query result]",
+          "cachingTimeout": "[Cache timeout time span]"
         }
       }
     },
     {
-      "xsltTransform": [Name of XSLT file],
+      "xsltTransform": "[Name of XSLT file]",
       "extensions": [
         {
-          "namespace": [Assembly namespace],
-           "assemblyName": [Assembly name],
-           "className": [Assembly class name],
+          "namespace": "[Assembly namespace]",
+           "assemblyName": "[Assembly name]",
+           "className": "[Assembly class name]",
            "dependencies": [
              "[DLL dependency file name]",
              "[DLL dependency file name]"
@@ -284,21 +394,14 @@ This instruction is only available when calling the `/TranscoXML` endpoint.
   ],
   "options": {
     "configCache": {
-      "useCaching": [If true, config file is cached],
-      "cachingTimeout": [Cache timeout time span]
+      "useCaching": "[If true, config file is cached]",
+      "cachingTimeout": "[Cache timeout time span]"
     },
-    "indentResult": [If true, Transco results will be formatted and indented]
+    "indentResult": "[If true, Transco results will be formatted and indented]"
   }
  }
 ```
 </details>
-
-:::info[storage account]
-Save all required files in the Azure Storage Account and in a Blob Storage container with the name: `Transcov2configstore` (Invictus automatically creates this container):
-* `/Configs` folder with Transco config files
-* `/XSLTs` folder with transformation files
-* `/Assemblies` folder with assembly and dependency DLL files
-:::
 
 </TabItem>
 <TabItem value="matrix-basic" label="Matrix basic promote">
@@ -312,102 +415,183 @@ Transco XML/JSON operations also support promotion of values to the context.
 The SQL operation will now save the result to the context.
 :::
 
-| Supported request parameter | type                                                            |
-| --------------------------- | --------------------------------------------------------------- |
-| `KeyValueCollection`        | Key-Value collection <br/> (each pair is individually promoted) |
-| `Flow`                      | `string`                                                        |
-| `Domain`                    | `string`                                                        |
-| `Service`                   | `string`                                                        |
-| `Action`                    | `string`                                                        |
-| `Version`                   | `string`                                                        |
-| `Sender`                    | `string`                                                        |
-| `ApplicationName`           | `string`                                                        |
-| `Milestone`                 | `string`                                                        |
-| `ConversationId`            | `string`                                                        |
-| `CorrelationId`             | `string`                                                        |
-| `BatchId`                   | `string`                                                        |
-| `Data1`                     | `string`                                                        |
-| `Data2`                     | `string`                                                        |
-| `Data3`                     | `string`                                                        |
-
-<details>
-<summary>**Full request body JSON example**</summary>
-
-```json
-// POST /api/api/MatrixBasicPromote
-{
- "Content":  "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
- "Context":  {
- "x-conversationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",
- "x-correlationId":  "fc13d345-ebd7-44f2-89a9-4371258c0a08",
- "x-batchId":  "975f7ea4-6247-431b-afb6-6d27fb47516f",
- "x-applicationName":  "InvoiceApp",
- "filter":  "endtoendintegrationtests"	    
- },   
- "KeyValueCollection":  {
-  "w":  3,
-  "l":  10.2,
-  "h":  1,
-  "t":  200,
- },
- "Flow":  "fl1",
- "Domain":  "do",
- "Service":  "sr1",
- "Action":  "Ac",
- "Version":  "Vs",
- "Sender":  "Snd",
- "ApplicationName":  "Snd",
- "Milestone":  "2018",
- "ConversationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",   
- "CorrelationId":  "29500405-d7cf-4877-a72b-a3288cff9dc0", 
- "BatchId":  "29500405-d7cf-4877-a72b-a3288cff9dc0",  
- "Data1":  "d1", 
- "Data2":  "d2", 
- "Data3":  "d3"
-}
-```
-</details>
-
-<details>
-<summary>**Full response body JSON example**</summary>
-
-```json
-// 200 OK /api/api/MatrixBasicPromote
-{
-    "content": "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
-    "context": {
-        "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0",
-        "x-correlationId": "fc13d345-ebd7-44f2-89a9-4371258c0a08",
-        "x-batchId": "975f7ea4-6247-431b-afb6-6d27fb47516f",
-        "x-applicationName": "InvoiceApp",
-        "filter": "endtoendintegrationtests",
-        "Flow": "fl1",
-        "Domain": "do",	    
-        "Service": "sr1",
-        "Action": "Ac",
-        "Version": "Vs",
-        "ApplicationName": "Snd",
-        "Milestone": "2018",
-        "Data1": "d1",
-        "Data2": "d2",
-        "Data3": "d3",
-        "Sender": "Snd",
-        "w": 3,
-        "l": 10.2,
-        "h": 1,
-        "t": 200
+{/* vale off */}
+<ApiPlayground
+  method="POST"
+  path="/api/MatrixBasicPromote"
+  description="Accepts a list of parameters and promotes them to the `Context` in the response."
+  request={{
+    content: "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
+    context: {
+      "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0",
+      "x-correlationId": "fc13d345-ebd7-44f2-89a9-4371258c0a08",
+      "x-batchId": "975f7ea4-6247-431b-afb6-6d27fb47516f",
+      "x-applicationName": "InvoiceApp",
+      "filter": "salesforceconnector"
     },
-    "conversationId": null,
-    "correlationId": null,
-    "batchId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
-}
-```
-</details>
+    keyValueCollection: {
+      customer: "John Doe",
+      amount: 50,
+      currency: "GBP"
+    },
+    flow: "fl1",
+    domain: "sales"
+  }}
+  parameters={[
+    {
+      name: "content",
+      type: "string",
+      required: true,
+      description: "The input content as a Base64-encoded string."
+    },
+    {
+      name: "context",
+      type: "object",
+      required: false,
+      description: "The dictionary providing context to the conversion, gets copied 1:1 to the response."
+    },
+    {
+      name: "keyValueCollection",
+      type: "object",
+      required: false,
+      description: "A collection of key-value pairs to promote to the context."
+    },
+    {
+      name: "flow",
+      type: "string",
+      required: false,
+      description: "The flow identifier for the request."
+    },
+    {
+      name: "domain",
+      type: "string",
+      required: false,
+      description: "The domain identifier for the request."
+    },
+    {
+      name: "service",
+      type: "string",
+      required: false,
+      description: "The service identifier for the request."
+    },
+    {
+      name: "action",
+      type: "string",
+      required: false,
+      description: "The action identifier for the request."
+    },
+    {
+      name: "version",
+      type: "string",
+      required: false,
+      description: "The version identifier for the request."
+    },
+    {
+      name: "sender",
+      type: "string",
+      required: false,
+      description: "The sender identifier for the request."
+    },
+    {
+      name: "applicationName",
+      type: "string",
+      required: false,
+      description: "The application name for the request."
+    },
+    {
+      name: "milestone",
+      type: "string",
+      required: false,
+      description: "The milestone identifier for the request."
+    },
+    {
+      name: "conversationId",
+      type: "string",
+      required: false,
+      description: "The conversation identifier for the request."
+    },
+    {
+      name: "correlationId",
+      type: "string",
+      required: false,
+      description: "The correlation identifier for the request."
+    },
+    {
+      name: "batchId",
+      type: "string",
+      required: false,
+      description: "The batch identifier for the request."
+    },
+    {
+      name: "data1",
+      type: "string",
+      required: false,
+      description: "The data1 identifier for the request."
+    },
+    {
+      name: "data2",
+      type: "string",
+      required: false,
+      description: "The data2 identifier for the request."
+    },
+    {
+      name: "data3",
+      type: "string",
+      required: false,
+      description: "The data3 identifier for the request."
+    }
+  ]}
+  responses={[
+    {
+      status: 200,
+      label: "Success",
+      description: "The Transco component successfully promoted values to the context.",
+      body: {
+        content: "ew0KICAiQ291bnRyeUNvZGUiOiAiQkUiLA0KICAiTW9uZXkiOiAgeyAiQW1vdW50IjogIDUwLCAiQ3VycmVuY3kiOiAgIkdCUCIgIH0NCn0NCg==",
+        context: {
+          "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0",
+          "x-correlationId": "fc13d345-ebd7-44f2-89a9-4371258c0a08",
+          "x-batchId": "975f7ea4-6247-431b-afb6-6d27fb47516f",
+          "x-applicationName": "InvoiceApp",
+          "filter": "salesforceconnector",
+          "flow": "fl1",
+          "domain": "sales",
+          "service": null,
+          "action": null,
+          "version": null,
+          "sender": null,
+          "applicationName": null,
+          "milestone": null,
+          "conversationId": null,
+          "correlationId": null,
+          "batchId": null,
+          "data1": null,
+          "data2": null,
+          "data3": null,
+          "customer": "John Doe",
+          "amount": 50,
+          "currency": "GBP"
+        }
+      }
+    },
+    {
+      status: 400,
+      label: "Invalid request",
+      description: "The request was invalid or missing required parameters.",
+      body: "Failed to promote values to the context because the request body did not contain a valid JSON with the required fields."
+    },
+    {
+      status: 500,
+      label: "Internal Server Error",
+      description: "An error occurred while processing the request.",
+      body: "Failed to promote values to the context because an unexpected error occurred, please see the logs for more details."
+    }
+  ]}
+/>
+{/* vale on */}
 
 </TabItem>
 </Tabs>
 
-___
-
-## Related Bicep template parameters
+### Related Bicep template parameters
 <ParameterTable parameters={parameters} fixedTags={[`comp:transco`]} />

--- a/versioned_docs/version-v6.0.0/framework/xmljsonconverter.mdx
+++ b/versioned_docs/version-v6.0.0/framework/xmljsonconverter.mdx
@@ -11,6 +11,11 @@ import parameters from "@site/src/data/framework.v6.bicep.parameters.json";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {faArrowRight} from '@fortawesome/free-solid-svg-icons';
 import ComponentHeader from "@site/src/components/ComponentHeader";
+import { faArrowsRotate } from "@fortawesome/free-solid-svg-icons";
+import ComponentFlowDiagram from "@site/src/components/Diagrams/ComponentFlowDiagram";
+import {Walkthrough, Collapsible} from "@site/src/components/Walkthrough";
+import { faRotateBack } from '@fortawesome/free-solid-svg-icons';
+import ApiPlayground from "@site/src/components/ApiPlayground";
 
 <ComponentHeader
   icon="/img/icons/xml-json-converter.png"
@@ -24,106 +29,215 @@ To run simple XML/JSON transformations, the built-in Logic Apps expressions [`js
 Invictus provides a **XML/JSON Converter** component which converts XML/JSON contents, while running a XSLT transformation beforehand (stored in Azure Blob Storage). Removing the complexity from the Logic App
 :::
 
-## Available endpoints
-* `/api/XmlToJson`: transforms incoming request with XML contents to a response with the JSON result.
-* `/api/JsonToXml`: transforms incoming request with JSON contents to a response with the XML result. 
+## Component usage
+{/* vale off */}
+<ComponentFlowDiagram
+  name="XML/JSON Converter"
+  tagline="Format conversion with XSLT transformation"
+  icon={faArrowsRotate}
+  rows={[
+    {
+      input: "XML",
+      opTitle: "XML → JSON",
+      opSubtitle: "XSLT transformation",
+      output: "JSON",
+      storageLabel: "Azure Blob Storage",
+    },
+    {
+      input: "JSON",
+      opTitle: "JSON → XML",
+      opSubtitle: "XSLT transformation",
+      output: "XML",
+      storageLabel: "Azure Blob Storage",
+    },
+  ]}
+/>
+{/* vale on */}
 
-<Tabs groupId="xml-json-conversions">
-<TabItem value="xml-json" label="XML-JSON">
+<Walkthrough>
+<Collapsible number={<FontAwesomeIcon icon={faArrowsRotate} />} title="XML → JSON">
 
-The `/api/XmlToJson` endpoint transforms a provided BASE 64-encoded XML contents to a BASE 64-encoded JSON result. A XSLT transformation (stored in the Azure Blob Storage container called `xmltojsonconfigstore`) gets run beforehand to map the request in the right structure. This stored transformation gets referenced in the request. 
-
-| Request property | Required | Description                                                                               |
-| ---------------- | :------: | ----------------------------------------------------------------------------------------- |
-| `Content`        |   yes    | The BASE 64-encoded XML contents.                                                         |
-| `ConfigName`     |   yes    | The filename of the XSLT transformation, stored in Azure Blob Storage.                   |
-| `Context`        |    no    | The dictionary providing context to the conversion, gets copied 1:1 to the response.      |
-| `XPath`          |    no    | The XPath expression that selects a specific XML node before the XSLT transformation.     |
-| `JPath`          |    no    | The JPath expression that selects a specific JSON property after the XSLT transformation. |
-
-<details>
-<summary>**Full request JSON body example**</summary>
-
-```json
-// POST /api/XmlToJson
-{
-    "Content": "eyJFbnZlbG9wZSI6IHiU2FsZXNPcmRlckluIjp7ICAgICAgICAg...." ,
-    "ConfigName":"IDD038-inbound.xsl",
-    "XPath": "/CustomerAccount/Message",
-    "JPath": "$.Envelope",
-    "Context": {
+{/* vale off */}
+<ApiPlayground
+  method="POST"
+  path="/api/XmlToJson"
+  description="Transforms a Base64-encoded XML document to a Base64-encoded JSON document, using a XSLT transformation stored in Azure Blob Storage (container=`xmltojsonconfigstore`)."
+  request={{
+    content: "eyJFbnZlbG9wZSI6IHiU2FsZXNPcmRlckluIjp7ICAgICAgICAg...." ,
+    configName:"IDD038-inbound.xsl",
+    xPath: "/CustomerAccount/Message",
+    jPath: "$.Envelope",
+    context: {
         "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
     }
-}
-```
-</details>
+  }}
+  parameters={[
+    {
+        name: "content",
+        type: "string",
+        required: true,
+        description: "The input XML document as a Base64-encoded string."
+    },
+    {
+        name: "configName",
+        type: "string",
+        required: true,
+        description: "The filename of the XSLT transformation, stored in Azure Blob Storage (container=`xmltojsonconfigstore`)."
+    },
+    {
+        name: "xPath",
+        type: "string",
+        required: false,
+        description: "The XPath expression that selects a specific XML node before the XSLT transformation."
+    },
+    {
+        name: "jPath",
+        type: "string",
+        required: false,
+        description: "The JPath expression that selects a specific JSON property after the XSLT transformation."
+    },
+    {
+        name: "context",
+        type: "object",
+        required: false,
+        description: "The dictionary providing context to the conversion, gets copied 1:1 to the response."
+    }
+  ]}
+  responses={[
+    {
+      status: 200,
+      label: "Success",
+      description: "The XML was successfully transformed to JSON.",
+      body: {
+        content: "ejHixZlwI9HiU2FsxNPcmRluIjp7ICAgICagICa...",
+        context: {
+            "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
+        }
+      }
+    },
+    {
+        status: 400,
+        label: "Invalid request",
+        description: "The request body could not be parsed. Ensure the request body is a valid JSON with the required fields.",
+        body: "Failed to transform the input XML to JSON because the request body was not a JSON with an Base64-encoded XML document and a XSLT transformation name."
+    },
+    {
+        status: 400,
+        label: "Invalid XML or JSON",
+        description: "The provided XML or JSON document result is not valid.",
+        body: "Failed to transform the input XML to JSON because the provided XML is not valid."
+    },
+    {
+        status: 404,
+        label: "XPath or JPath Not Found",
+        description: "The provided XPath or JPath expression did not match any node in the XML or JSON document.",
+        body: "Failed to transform the input XML to JSON because the provided XPath or JPath expression did not match any node in the XML or JSON document."
+    },
+    {
+        status: 500,
+        label: "Internal Server Error",
+        description: "An unexpected error occurred during the transformation process.",
+        body: "Failed to transform the input XML to JSON because an unexpected error occurred during the transformation process."
+    }
+  ]}
+/>
+{/* vale on */}
 
-<details>
-<summary>**Full response JSON body example**</summary>
+</Collapsible>
 
-```json
-// 200 OK <- /api/XmlToJson
-{
-    "Content": "ejHixZlwI9HiU2FsxNPcmRluIjp7ICAgICagICa...",
-    "Context": {
+<Collapsible number={<FontAwesomeIcon icon={faArrowsRotate} />} title="JSON → XML">
+
+{/* vale off */}
+<ApiPlayground
+  method="POST"
+  path="/api/JsonToXml"
+  description="Transforms a Base64-encoded JSON document to a Base64-encoded XML document, using a XSLT transformation stored in Azure Blob Storage (container=`xmltojsonconfigstore`)."
+  request={{
+    content: "eyJFbnZlbG9wZSI6IHiU2FsZXNPcmRlckluIjp7ICAgICAgICAg...." ,
+    configName:"IDD038-inbound.xsl",
+    jPath: "$.Envelope",
+    xPath: "/CustomerAccount/Message",
+    context: {
         "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
     }
-}
-```
-</details>
-
-</TabItem>
-
-
-<TabItem value="json-xml" label="JSON-XML">
-
-The `/api/JsonToXml` endpoint transforms a provided BASE 64-encoded JSON contents to a BASE 64-encoded XML result. A XSLT transformation (stored in the Azure Blob Storage container called `xmltojsonconfigstore`) gets run beforehand to map the request in the right structure. This stored transformation gets referenced in the request. 
-
-| Request property | Required | Description                                                                                |
-| ---------------- | :------: | ------------------------------------------------------------------------------------------ |
-| `Content`        |   yes    | The BASE 64-encoded JSON contents.                                                         |
-| `ConfigName`     |   yes    | The filename of the XSLT transformation, stored in Azure Blob Storage.                    |
-| `Context`        |    no    | The dictionary providing context to the conversion, gets copied 1:1 to the response.       |
-| `JPath`          |    no    | The XPath expression that selects a specific JSON property before the XSLT transformation. |
-| `XPath`          |    no    | The JPath expression that selects a specific XML node after the XSLT transformation.       |
-
-<details>
-<summary>**Full request JSON body example**</summary>
-
-```json
-// POST /api/JsonToXml
-{
-    "Content": "eyJFbnZlbG9wZSI6IHiU2FsZXNPcmRlckluIjp7ICAgICAgICAg...." ,
-    "ConfigName":"IDD038-inbound.xsl",
-    "JPath": "$.Envelope",
-    "XPath": "/CustomerAccount/Message",
-    "Context": {
-        "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
+  }}
+  parameters={[
+    {
+      name: "content",
+      type: "string",
+      required: true,
+      description: "The input JSON document as a Base64-encoded string."
+    },
+    {
+      name: "configName",
+      type: "string",
+      required: true,
+      description: "The filename of the XSLT transformation, stored in Azure Blob Storage (container=`xmltojsonconfigstore`)."
+    },
+    {
+      name: "jPath",
+      type: "string",
+      required: false,
+      description: "The JPath expression that selects a specific JSON property before the XSLT transformation."
+    },
+    {
+      name: "xPath",
+      type: "string",
+      required: false,
+      description: "The XPath expression that selects a specific XML node after the XSLT transformation."
+    },
+    {
+      name: "context",
+      type: "object",
+      required: false,
+      description: "The dictionary providing context to the conversion, gets copied 1:1 to the response."
     }
-}
-```
-</details>
-
-<details>
-<summary>**Full response JSON body example**</summary>
-
-```json
-// 200 OK <- /api/JsonToXml
-{
-    "Content": "ejHixZlwI9HiU2FsxNPcmRluIjp7ICAgICagICa...",
-    "Context": {
-        "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
+  ]}
+  responses={[
+    {
+      status: 200,
+      label: "Success",
+      description: "The JSON was successfully transformed to XML.",
+      body: {
+        content: "ejHixZlwI9HiU2FsxNPcmRluIjp7ICAgICagICa...",
+        context: {
+            "x-conversationId": "29500405-d7cf-4877-a72b-a3288cff9dc0"
+        }
+      }
+    },
+    {
+        status: 400,
+        label: "Invalid request",
+        description: "The request body could not be parsed. Ensure the request body is a valid JSON with the required fields.",
+        body: "Failed to transform the input JSON to XML because the request body was not a JSON with an Base64-encoded JSON document and a XSLT transformation name."
+    },
+    {
+        status: 400,
+        label: "Invalid XML or JSON",
+        description: "The provided JSON or XML document result is not valid.",
+        body: "Failed to transform the input JSON to XML because the provided JSON or XML is not valid."
+    },
+    {
+        status: 404,
+        label: "XPath or JPath Not Found",
+        description: "The provided XPath or JPath expression did not match any node in the XML or JSON document.",
+        body: "Failed to transform the input JSON to XML because the provided XPath or JPath expression did not match any node in the XML or JSON document."
+    },
+    {
+        status: 500,
+        label: "Internal Server Error",
+        description: "An unexpected error occurred during the transformation process.",
+        body: "Failed to transform the input JSON to XML because an unexpected error occurred during the transformation process."
     }
-}
-```
-</details>
-</TabItem>
+  ]}
+/>
 
-</Tabs>
+{/* vale on */}
+</Collapsible>
 
-___
+</Walkthrough>
 
 {/* vale Google.Headings = NO */}
-## Related Bicep template parameters
+### Related Bicep template parameters
 {/* vale Google.Headings = YES */}
 <ParameterTable parameters={parameters} fixedTags={[`comp:xml-json-converter`]} />

--- a/versioned_docs/version-v6.0.0/framework/xsd-validator.mdx
+++ b/versioned_docs/version-v6.0.0/framework/xsd-validator.mdx
@@ -10,7 +10,8 @@ import ComponentHeader from "@site/src/components/ComponentHeader";
 import ApiPlayground from "@site/src/components/ApiPlayground";
 import { Walkthrough, Collapsible } from "@site/src/components/Walkthrough";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCircleCheck, faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
+import { faCircleCheck, faFloppyDisk, faFileShield } from "@fortawesome/free-solid-svg-icons";
+import ComponentFlowDiagram from "@site/src/components/Diagrams/ComponentFlowDiagram";
 
 <ComponentHeader
   icon="/img/icons/xsd-validator.png"
@@ -25,9 +26,25 @@ The Invictus Framework provides a **XSD Validator** component that allows you to
 :::
 
 ## Component usage
+{/* vale off */}
+<ComponentFlowDiagram
+  name="XSD Validator"
+  tagline="XML schema validation"
+  icon={faFileShield}
+  rows={[
+    {
+      input: "XML document",
+      opTitle: "XSD Validator",
+      opSubtitle: "Schema validation",
+      output: "Validation result",
+      storageLabel: "Azure Blob Storage",
+    },
+  ]}
+/>
+{/* vale on */}
 
 <Walkthrough>
-<Collapsible number={<FontAwesomeIcon icon={faCircleCheck} />} title="XSD validate user XML" open={true}>
+<Collapsible number={<FontAwesomeIcon icon={faCircleCheck} />} title="XSD validate user XML">
 
 The **XSD Validator** has a single endpoint available. Given a user XML and a referenced XSD schema stored in Azure Blob Storage, the endpoint responds with the validation result and any schema violations found.
 


### PR DESCRIPTION
Streamlines the remaining Framework component diagrams with Invictus-styled coloring and layout. It uses the same fonts, border and strokes as the admonitions used throughout the documentation to give the feeling they belong to the same family. In case of logic app diagrams, the 'action' blocks are styled different with rounded corners to indicate specific Invictus interactions. For the remaining 'single endpoint' components, the API playground MDX module and a 'simple' sequence diagram was chosen.



All components use the 'dependency' label to showcase any Azure dependencies.

