### PR TITLE
fix(versions): hide next version from prod builds

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,7 @@ const config = {
           routeBasePath: '/',
           path: 'preview',
           sidebarCollapsible: false,
-          includeCurrentVersion: true,
+          includeCurrentVersion: process.env.CONTEXT !== 'production',
           breadcrumbs: false,
           admonitions: {
             keywords: ['praise'],


### PR DESCRIPTION
The Docusaurus config hardcoded the `includeCurrentVersion: true`, which meant that it always included the 'next' version (in our case v7) in production builds. This should only be the case for deploy previews and local builds. This PR makes use of Netlify's context environment variable to disable the 'next' version from production builds.

