### PR TITLE
feat(welcome): add welcome splash screen to explain doc split

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,9 +3,7 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   allowCypressEnv: false,
 
-
   e2e: {
-    supportFile: false,
     baseUrl: 'http://localhost:3000/',
     setupNodeEvents(on, config) {
       // implement node event listeners here

--- a/cypress/e2e/bicep-params-search.cy.js
+++ b/cypress/e2e/bicep-params-search.cy.js
@@ -10,7 +10,7 @@ describe('Bicep parameter search', () => {
     describe(route, () => {
 
       beforeEach(() => {
-        cy.visit(route);
+        cy.visit(route, { onBeforeLoad: bypassSplash });
         cy.get('[data-cy=search-input]').scrollIntoView().as('searchInput');
         // Table is collapsed on initial load — click the disclosure button to expand it.
         cy.get('[data-cy=disclosure-button]').click();

--- a/cypress/e2e/business-technical-toggle.cy.js
+++ b/cypress/e2e/business-technical-toggle.cy.js
@@ -59,7 +59,7 @@ describe('Business/Technical user toggle', () => {
       beforeEach(() => {
         cy.clearLocalStorage();
         cy.viewport(width, height);
-        cy.visit('/');
+        cy.visit('/', { onBeforeLoad: bypassSplash });
         cy.openSidebar(deviceName, Audience.BUSINESS);
       });
 
@@ -132,7 +132,7 @@ describe('Business/Technical user toggle', () => {
     beforeEach(() => {
       cy.clearLocalStorage();
       cy.viewport(375, 667);
-      cy.visit('/');
+      cy.visit('/', { onBeforeLoad: bypassSplash });
     });
 
     it('toggle is not present in the top navbar', () => {

--- a/cypress/e2e/faq-search.cy.js
+++ b/cypress/e2e/faq-search.cy.js
@@ -10,7 +10,7 @@ describe('FAQ — Help Center', () => {
   const PAGE = '/support/help-center-technical';
 
   beforeEach(() => {
-    cy.visit(PAGE);
+    cy.visit(PAGE, { onBeforeLoad: bypassSplash });
   });
 
   // ── Initial state ─────────────────────────────────────────────────────────

--- a/cypress/e2e/release-notes.cy.js
+++ b/cypress/e2e/release-notes.cy.js
@@ -11,7 +11,7 @@ describe('Release notes', () => {
   const url = '/support/release-notes';
 
   beforeEach(() => {
-    cy.visit(url);
+    cy.visit(url, { onBeforeLoad: bypassSplash });
   });
 
   describe('initial state', () => {

--- a/cypress/e2e/search-bar-navigation.cy.js
+++ b/cypress/e2e/search-bar-navigation.cy.js
@@ -10,7 +10,7 @@ describe('SearchBar navigation (local search)', () => {
   beforeEach(() => {
     // Block all Azure Search requests so local fallback always activates.
     cy.intercept('GET', '**/indexes/*/docs*', { forceNetworkError: true }).as('azureSearch');
-    cy.visit('/');
+    cy.visit('/', { onBeforeLoad: bypassSplash });
   });
 
   /**

--- a/cypress/e2e/welcome-splash.cy.js
+++ b/cypress/e2e/welcome-splash.cy.js
@@ -1,0 +1,123 @@
+/**
+ * Welcome splash screen tests.
+ *
+ * The splash renders when `invictus-user-type` is absent from localStorage
+ * (genuine first visit). It must never appear for returning visitors.
+ */
+describe('Welcome splash screen', () => {
+
+  // Helper: get the dialog element
+  const splash = () => cy.get('[role="dialog"][aria-labelledby="welcome-title"]');
+
+  beforeEach(() => {
+    // Simulate a genuine first visit — no stored user type.
+    cy.clearLocalStorage();
+  });
+
+  // ── Visibility ─────────────────────────────────────────────────────────────
+
+  it('appears on first visit', () => {
+    cy.visit('/');
+    splash().should('be.visible');
+  });
+
+  it('does not appear when a user type is already stored', () => {
+    cy.visit('/', { onBeforeLoad: bypassSplash });
+    splash().should('not.exist');
+  });
+
+  it('appears on any page, not only the root', () => {
+    cy.visit('/dashboard/flows');
+    splash().should('be.visible');
+  });
+
+  // ── Content ─────────────────────────────────────────────────────────────────
+
+  it('shows the welcome heading', () => {
+    cy.visit('/');
+    cy.get('#welcome-title').should('contain.text', 'Welcome to Invictus for Azure');
+  });
+
+  it('shows a Business user card and a Technical user card', () => {
+    cy.visit('/');
+    splash().within(() => {
+      cy.contains('button', 'Business user').should('be.visible');
+      cy.contains('button', 'Technical user').should('be.visible');
+    });
+  });
+
+  // ── Business user selection ─────────────────────────────────────────────────
+
+  it('dismisses the splash when Business user is chosen', () => {
+    cy.visit('/');
+    cy.contains('button', 'Business user').click();
+    splash().should('not.exist');
+  });
+
+  it('stores "business" in localStorage when Business user is chosen', () => {
+    cy.visit('/');
+    cy.contains('button', 'Business user').click();
+    cy.getAllLocalStorage().then((storage) => {
+      const site = storage['http://localhost:3000'] ?? storage[Object.keys(storage)[0]];
+      expect(site?.['invictus-user-type']).to.equal('business');
+    });
+  });
+
+  it('navigates to the business root after choosing Business user', () => {
+    cy.visit('/');
+    cy.contains('button', 'Business user').click();
+    cy.url().should('eq', Cypress.config('baseUrl'));
+  });
+
+  // ── Technical user selection ────────────────────────────────────────────────
+
+  it('dismisses the splash when Technical user is chosen', () => {
+    cy.visit('/');
+    cy.contains('button', 'Technical user').click();
+    splash().should('not.exist');
+  });
+
+  it('stores "technical" in localStorage when Technical user is chosen', () => {
+    cy.visit('/');
+    cy.contains('button', 'Technical user').click();
+    cy.getAllLocalStorage().then((storage) => {
+      const site = storage['http://localhost:3000'] ?? storage[Object.keys(storage)[0]];
+      expect(site?.['invictus-user-type']).to.equal('technical');
+    });
+  });
+
+  it('navigates to /technical after choosing Technical user', () => {
+    cy.visit('/');
+    cy.contains('button', 'Technical user').click();
+    cy.url().should('include', '/technical');
+  });
+
+  // ── Persistence ─────────────────────────────────────────────────────────────
+
+  it('does not reappear after a choice has been made', () => {
+    cy.visit('/');
+    cy.contains('button', 'Business user').click();
+    cy.visit('/');
+    splash().should('not.exist');
+  });
+
+  // ── Accessibility ───────────────────────────────────────────────────────────
+
+  it('focuses the first card on open for keyboard users', () => {
+    cy.visit('/');
+    cy.contains('button', 'Business user').should('be.focused');
+  });
+
+  it('Business user card is selectable via keyboard Enter', () => {
+    cy.visit('/');
+    cy.contains('button', 'Business user').focus().type('{enter}');
+    splash().should('not.exist');
+  });
+
+  it('Technical user card is selectable via keyboard Enter', () => {
+    cy.visit('/');
+    cy.contains('button', 'Technical user').focus().type('{enter}');
+    splash().should('not.exist');
+  });
+
+});

--- a/cypress/e2e/welcome-splash.cy.js
+++ b/cypress/e2e/welcome-splash.cy.js
@@ -120,6 +120,7 @@ describe('Welcome splash screen', () => {
 
   it('Technical user card is selectable via keyboard Enter', () => {
     cy.visit('/');
+    cy.contains('button', 'Technical user').should('be.focused');
     cy.contains('button', 'Technical user').focus().type('{enter}');
     splash().should('not.exist');
   });

--- a/cypress/e2e/welcome-splash.cy.js
+++ b/cypress/e2e/welcome-splash.cy.js
@@ -12,6 +12,7 @@ describe('Welcome splash screen', () => {
   beforeEach(() => {
     // Simulate a genuine first visit — no stored user type.
     cy.clearLocalStorage();
+    cy.wait(100);
   });
 
   // ── Visibility ─────────────────────────────────────────────────────────────
@@ -35,7 +36,9 @@ describe('Welcome splash screen', () => {
 
   it('shows the welcome heading', () => {
     cy.visit('/');
-    cy.get('#welcome-title').should('contain.text', 'Welcome to Invictus for Azure');
+    cy.get('#welcome-title')
+      .should('contain.text', 'Welcome')
+      .should('contain.text', 'Invictus for Azure');
   });
 
   it('shows a Business user card and a Technical user card', () => {
@@ -110,6 +113,7 @@ describe('Welcome splash screen', () => {
 
   it('Business user card is selectable via keyboard Enter', () => {
     cy.visit('/');
+    cy.contains('button', 'Business user').should('be.focused');
     cy.contains('button', 'Business user').focus().type('{enter}');
     splash().should('not.exist');
   });

--- a/cypress/e2e/welcome-splash.cy.js
+++ b/cypress/e2e/welcome-splash.cy.js
@@ -113,14 +113,14 @@ describe('Welcome splash screen', () => {
 
   it('Business user card is selectable via keyboard Enter', () => {
     cy.visit('/');
-    cy.contains('button', 'Business user').should('be.focused');
+    cy.contains('button', 'Business user').should('be.visible');
     cy.contains('button', 'Business user').focus().type('{enter}');
     splash().should('not.exist');
   });
 
   it('Technical user card is selectable via keyboard Enter', () => {
     cy.visit('/');
-    cy.contains('button', 'Technical user').should('be.focused');
+    cy.contains('button', 'Technical user').should('be.visible');
     cy.contains('button', 'Technical user').focus().type('{enter}');
     splash().should('not.exist');
   });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,12 @@
+/**
+ * Global e2e support file — loaded before every spec.
+ */
+
+/**
+ * Inject the user-type key into localStorage before the page loads, preventing
+ * the welcome splash from appearing in tests that don't explicitly test it.
+ *
+ * Usage: cy.visit('/some-page', { onBeforeLoad: bypassSplash })
+ */
+globalThis.bypassSplash = (win) =>
+  win.localStorage.setItem('invictus-user-type', 'business');

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -74,6 +74,10 @@ const config = {
       process.env.AZURE_OPENAI_ENDPOINT &&
       process.env.AZURE_OPENAI_DEPLOYMENT
     ),
+    // Netlify sets CONTEXT='deploy-preview' for PR previews and 'branch-deploy'
+    // for branch deploys. Skip the welcome splash in both so reviewers land
+    // directly on the content without needing to choose a user type.
+    isPreviewDeploy: ['deploy-preview', 'branch-deploy'].includes(process.env.CONTEXT),
   },
 
   themeConfig: {

--- a/src/components/UserTypeContext.js
+++ b/src/components/UserTypeContext.js
@@ -4,6 +4,7 @@ import { usePluginData } from '@docusaurus/useGlobalData';
 import versions from '../../versions.json';
 
 const STORAGE_KEY = 'invictus-user-type';
+export { STORAGE_KEY };
 const BUSINESS_ROOT = '/';
 const TECHNICAL_ROOT = '/technical';
 
@@ -79,6 +80,10 @@ export function UserTypeProvider({ children }) {
 
   useEffect(() => {
     if (!sidebar) return;
+    // Only auto-detect if the user has already made a choice (key exists).
+    // On first visit the key is absent — let WelcomeSplash handle the initial choice
+    // so path detection doesn't silently pre-fill localStorage and skip the splash.
+    try { if (localStorage.getItem(STORAGE_KEY) === null) return; } catch { }
     const path = location.pathname.replace(/^\/|\/$/g, '');
     const detected = detectUserTypeFromPath(path, businessIds, technicalIds);
     if (detected) setUserType(detected);

--- a/src/components/WelcomeSplash/index.jsx
+++ b/src/components/WelcomeSplash/index.jsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useHistory } from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { useUserType, STORAGE_KEY } from '../UserTypeContext';
+import styles from './styles.module.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBuilding, faCogs } from '@fortawesome/free-solid-svg-icons';
+
+const ROLES = [
+  {
+    key: 'business',
+    path: '/',
+    icon: <FontAwesomeIcon icon={faBuilding} />,
+    title: 'Business user',
+    description:
+      'I work in management or operations and want to understand what Invictus can do for my organization.',
+  },
+  {
+    key: 'technical',
+    path: '/technical',
+    icon: <FontAwesomeIcon icon={faCogs} />,
+    title: 'Technical user',
+    description:
+      "I'm a developer or architect and want to build integrations using the Invictus product.",
+  },
+];
+
+const FOCUSABLE = 'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export default function WelcomeSplash() {
+  const { siteConfig } = useDocusaurusContext();
+  const [visible, setVisible] = useState(false);
+  const { setUserType } = useUserType();
+  const history = useHistory();
+  const firstCardRef = useRef(null);
+  const dialogRef = useRef(null);
+
+  // Only check localStorage on the client (SSR safety)
+  useEffect(() => {
+    // Skip splash entirely on Netlify preview/branch deploys so reviewers
+    // land directly on content. Defaults to business user silently.
+    if (siteConfig.customFields?.isPreviewDeploy) return;
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === null) {
+        setVisible(true);
+      }
+    } catch {
+      // localStorage unavailable — skip splash
+    }
+  }, []);
+
+  // Lock scroll and move focus into dialog when it opens
+  useEffect(() => {
+    if (!visible) return;
+    document.body.style.overflow = 'hidden';
+    firstCardRef.current?.focus();
+    return () => { document.body.style.overflow = ''; };
+  }, [visible]);
+
+  // Focus trap: keep Tab cycling within the dialog (WCAG 2.1.1, 2.4.3)
+  function handleKeyDown(e) {
+    if (e.key !== 'Tab') return;
+    const nodes = dialogRef.current?.querySelectorAll(FOCUSABLE);
+    if (!nodes?.length) return;
+    const first = nodes[0];
+    const last = nodes[nodes.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  function choose(role) {
+    setUserType(role.key);
+    setVisible(false);
+    history.replace(role.path);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      ref={dialogRef}
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="welcome-title"
+      aria-describedby="welcome-desc"
+      onKeyDown={handleKeyDown}
+    >
+      <div className={styles.panel}>
+        <img src="/img/invictus-logo_negative_white.png" alt="Invictus for Azure" className={styles.logo} />
+
+        <h1 id="welcome-title" className={styles.heading}>
+          Welcome to the <span className={styles.highlight}>Invictus for Azure</span> documentation
+        </h1>
+
+        <p id="welcome-desc" className={styles.intro}>
+          Invictus is an enterprise integration framework built by <a href="https://www.codit.eu/" target="_blank" rel="noopener noreferrer">Codit</a> on Microsoft Azure to help organizations interact with their business processes in an intuitive way.
+          <br /><br />This documentation site is tailored for two audiences — choose the one that fits you best.
+          You can always change your selection later.
+        </p>
+
+        <p className={styles.prompt}>Who are you?</p>
+
+        <div className={styles.cards}>
+          {ROLES.map((role, i) => (
+            <button
+              key={role.key}
+              ref={i === 0 ? firstCardRef : undefined}
+              className={styles.card}
+              onClick={() => choose(role)}
+            >
+              <span className={styles.cardIcon} aria-hidden="true">{role.icon}</span>
+              <span className={styles.cardTitle}>{role.title}</span>
+              <span className={styles.cardDesc}>{role.description}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WelcomeSplash/index.jsx
+++ b/src/components/WelcomeSplash/index.jsx
@@ -113,6 +113,7 @@ export default function WelcomeSplash() {
               ref={i === 0 ? firstCardRef : undefined}
               className={styles.card}
               onClick={() => choose(role)}
+              onKeyDown={(e) => { if (e.key === 'Enter') choose(role); }}
             >
               <span className={styles.cardIcon} aria-hidden="true">{role.icon}</span>
               <span className={styles.cardTitle}>{role.title}</span>

--- a/src/components/WelcomeSplash/styles.module.css
+++ b/src/components/WelcomeSplash/styles.module.css
@@ -1,0 +1,179 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background-color: #002b32;
+  /* --ifm-color-primary-darkest */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  animation: fadeIn 0.35s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.panel {
+  max-width: 780px;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.logo {
+  height: 180px;
+  width: auto;
+  margin-bottom: 0rem;
+}
+
+.heading {
+  color: #ffffff;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.intro {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 1rem;
+  max-width: 540px;
+  line-height: 1.65;
+  margin: 0;
+}
+
+.intro a {
+  color: var(--ifm-color-primary-lightest);
+  text-decoration: underline;
+  font-weight: 700;
+}
+
+.intro a:hover,
+.intro a:focus {
+  color: var(--ifm-color-primary-light);
+  text-decoration: none;
+}
+
+.highlight {
+  color: var(--ifm-color-primary-lightest);
+  font-weight: 700;
+}
+
+.prompt {
+  color: var(--ifm-color-secondary);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin: 0.75rem 0 0;
+}
+
+.cards {
+  display: flex;
+  gap: 1.25rem;
+  width: 100%;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
+}
+
+.card {
+  flex: 1;
+  min-width: 260px;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 1.5rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.40);
+  /* 0.40 opacity = 3.58:1 contrast (WCAG 1.4.11) */
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: center;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+  color: #ffffff;
+}
+
+.card:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.32);
+  transform: translateY(-3px);
+}
+
+.card:focus-visible {
+  outline: 2px solid #2a8f9c;
+  outline-offset: 4px;
+}
+
+.cardIcon {
+  font-size: 2.25rem;
+  line-height: 1;
+}
+
+.cardTitle {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.cardDesc {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.62);
+  line-height: 1.55;
+}
+
+@media screen and (max-width: 640px) {
+  .panel {
+    gap: 0.5rem;
+  }
+
+  .logo {
+    height: 120px;
+  }
+
+  .heading {
+    font-size: 1.25rem;
+  }
+
+  .intro {
+    font-size: 0.875rem;
+    max-width: 100%;
+  }
+
+  .cards {
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+  }
+
+  .card {
+    padding: 1.5rem 1rem;
+    min-width: unset;
+    max-width: unset;
+  }
+}
+
+/* Respect the user's motion preference (WCAG 2.3.3 / prefers-reduced-motion) */
+@media (prefers-reduced-motion: reduce) {
+  .overlay {
+    animation: none;
+  }
+
+  .card {
+    transition: none;
+  }
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useLocation } from '@docusaurus/router';
 import { UserTypeProvider } from '../components/UserTypeContext';
+import WelcomeSplash from '../components/WelcomeSplash';
 
 // ── SearchHighlighter ──────────────────────────────────────────────────────
 // Reads ?highlight=<term> from the URL after a search-result navigation,
@@ -288,8 +289,8 @@ function SearchHighlighter() {
       clearTimeout(debounceTimer);
       clearTimeout(stableTimer);
     };
-  // location.href is undefined in React Router's location object — use the
-  // individual parts that actually change on navigation as dependencies.
+    // location.href is undefined in React Router's location object — use the
+    // individual parts that actually change on navigation as dependencies.
   }, [location.pathname, location.search, location.hash]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return null;
@@ -332,6 +333,7 @@ export default function Root({ children }) {
     <UserTypeProvider>
       <HashScrollHandler />
       <SearchHighlighter />
+      <WelcomeSplash />
       {children}
     </UserTypeProvider>
   );


### PR DESCRIPTION
First-time users will see a welcome splash screen that explains the purpose of the site and the split in audiences. This screen only shows for the initial navigation to not assume people know directly what role they play.

