### PR TITLE
fix(prog.import-jobs): remove unused azure link from prog. import jobs

### DIFF
--- a/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import-flow-prog-via-eh.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import-flow-prog-via-eh.mdx
@@ -133,16 +133,3 @@ If an event represents an error, it can provide context information in the form 
    }
 }
 ```
-
-### Azure link on events
-Add a link and resource ID if you can track back an event to Azure. These details populates the Dashboard for a click-through experience.
-
-```json
-// event
-{
-   "Azure": {
-      "ResourceId": "/subscriptions/.../resourceGroups/...",
-      "PortalLink": "https://portal.azure.com/to-your-resource"
-   }
-}
-```

--- a/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import-flow-prog-via-http.mdx
+++ b/versioned_docs/version-v6.0.0/dashboard/flows/04_import-flow-traces/import-flow-prog-via-http.mdx
@@ -132,16 +132,3 @@ If an event represents an error, it can provide context information in the form 
    }
 }
 ```
-
-### Azure link on events
-Add a link and resource ID if you can track back an event to Azure. These details populates the Dashboard for a click-through experience.
-
-```json
-// event
-{
-   "Azure": {
-      "ResourceId": "/subscriptions/.../resourceGroups/...",
-      "PortalLink": "https://portal.azure.com/to-your-resource"
-   }
-}
-```


### PR DESCRIPTION
Remove the unused and incorrect usage of the 'Azure link' in the programmatically import jobs HTTP and Event Hubs. A request on message content view leant to the discovery of this problem.

