### PR TITLE
fix(release-notes): add missing tab title for release notes page

### DIFF
--- a/versioned_docs/version-v6.0.0/support/release-notes.mdx
+++ b/versioned_docs/version-v6.0.0/support/release-notes.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Release notes
+title: Release notes
 hide_table_of_contents: true
 pagination_prev: null
 pagination_next: null


### PR DESCRIPTION
The release notes page was missing a tab title, resulting in showing the file name in the tab. This PR fixes that.

