### PR TITLE
fix(sidebar): cache drift on new actionable sidebar

### DIFF
--- a/src/components/MobileNavContext.js
+++ b/src/components/MobileNavContext.js
@@ -1,57 +1,26 @@
-import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 
-// Sidebar items (processed PropSidebar objects) are plain JSON-serializable data.
-// Persisting them in localStorage means the overlay works cross-page without a
-// seed navigation on every fresh load.
-const STORAGE_KEY = 'invictus-mobile-sidebars';
-const CACHE_VERSION = 2;
-
-function readCache() {
-  if (typeof window === 'undefined') return {};
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    // Bust stale caches from earlier buggy sessions.
-    if (parsed._v !== CACHE_VERSION) return {};
-    return parsed.data ?? {};
-  } catch {
-    return {};
-  }
-}
-
-function writeCache(sidebars) {
-  if (typeof window === 'undefined') return;
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ _v: CACHE_VERSION, data: sidebars }));
-  } catch { }
-}
-
-const MobileNavContext = createContext({ sidebars: {}, setSidebarForType: () => {} });
+// Bridge that carries the CURRENT page's real, live sidebar out to the
+// Navbar-level mobile audience overlay (which renders outside the doc page's
+// DocsSidebarProvider tree, so it can't call useDocsSidebar() itself).
+//
+// This only ever holds a snapshot of whatever page is genuinely being
+// rendered right now — never a persisted cache of a *different* section kept
+// around for an instant "preview" swap. That earlier design (cross-section
+// caching, persisted to localStorage) caused a real bug: switching sections
+// without navigating could show a stale sidebar left over from before a
+// content change, only fixed by a hard refresh. Keeping this in-memory only,
+// and always overwritten by the real current page, means there is nothing
+// that can go stale — switching sections now always triggers a real
+// navigation (see UserTypeSwitcher / Navbar/Layout), which is what refreshes
+// this value.
+const MobileNavContext = createContext({ sidebar: null, setSidebar: () => {} });
 
 export function MobileNavProvider({ children }) {
-  // Initialize empty to match SSR output (avoids hydration mismatch).
-  const [sidebars, setSidebars] = useState({});
-
-  // After hydration, restore both sidebars from the cache so the overlay can
-  // open immediately without a seed navigation on subsequent page loads.
-  useEffect(() => {
-    const cached = readCache();
-    if (Object.keys(cached).length > 0) {
-      setSidebars(cached);
-    }
-  }, []);
-
-  const setSidebarForType = useCallback((type, data) => {
-    setSidebars((prev) => {
-      const next = { ...prev, [type]: data };
-      writeCache(next);
-      return next;
-    });
-  }, []);
+  const [sidebar, setSidebar] = useState(null);
 
   return (
-    <MobileNavContext.Provider value={{ sidebars, setSidebarForType }}>
+    <MobileNavContext.Provider value={{ sidebar, setSidebar }}>
       {children}
     </MobileNavContext.Provider>
   );

--- a/src/components/UserTypeSwitcher.js
+++ b/src/components/UserTypeSwitcher.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useHistory } from '@docusaurus/router';
 import { useUserType } from './UserTypeContext';
-import { useMobileNav } from './MobileNavContext';
 import styles from './UserTypeSwitcher.module.css';
 
 const TABS = [
@@ -11,18 +10,15 @@ const TABS = [
 
 export default function UserTypeSwitcher() {
   const { userType, setUserType } = useUserType();
-  const { sidebars } = useMobileNav();
   const history = useHistory();
 
   function handleSelect(e, tab) {
     e.preventDefault();
+    if (tab.key === userType) return;
     setUserType(tab.key);
-    // Only navigate when the target sidebar hasn't been cached yet.
-    // Once both sidebars are in the cache, switching just swaps the items
-    // in place — no page navigation.
-    if (!sidebars[tab.key]) {
-      history.push(tab.path);
-    }
+    // Always navigate for real — this guarantees the destination sidebar is
+    // always the live, current one, never a stale cached snapshot.
+    history.push(tab.path);
   }
 
   return (

--- a/src/theme/DocSidebar/Desktop/Content.js
+++ b/src/theme/DocSidebar/Desktop/Content.js
@@ -1,37 +1,17 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import OriginalContent from '@theme-original/DocSidebar/Desktop/Content';
-import { useDocsSidebar } from '@docusaurus/plugin-content-docs/client';
 import UserTypeSwitcher from '../../../components/UserTypeSwitcher';
-import { useUserType } from '../../../components/UserTypeContext';
-import { useMobileNav } from '../../../components/MobileNavContext';
 
+// Switching sections now always navigates for real (see UserTypeSwitcher),
+// so this always shows the real sidebar for whatever page is being viewed —
+// no cross-section caching/preview to keep in sync or go stale.
 export default function DocSidebarDesktopContent(props) {
-  const { sidebars, setSidebarForType } = useMobileNav();
-  const { userType } = useUserType();
-  const docsSidebar = useDocsSidebar();
-  const sidebarName = docsSidebar?.name ?? '';
-  const currentType = sidebarName === 'technical_users' ? 'technical' : 'business';
-
-  // Populate the shared cache whenever this page's sidebar is available.
-  // This mirrors what DocSidebar/Mobile does on mobile, so both desktop and
-  // mobile sessions always have both sidebars cached after first visit.
-  useEffect(() => {
-    if (!props.sidebar?.length || !sidebarName) return;
-    setSidebarForType(currentType, { items: props.sidebar, path: props.path });
-  }, [props.sidebar, props.path, sidebarName, currentType, setSidebarForType]);
-
-  // When the user switched to the other section (without navigating), show
-  // the cached items for that section. activePath stays as the real page
-  // permalink — no items will highlight, which is correct until they navigate.
-  const cachedItems = sidebars[userType]?.items;
-  const displayItems = (userType !== currentType && cachedItems) ? cachedItems : props.sidebar;
-
   return (
     <>
       <div className="sidebar-switcher">
         <UserTypeSwitcher />
       </div>
-      <OriginalContent {...props} sidebar={displayItems} />
+      <OriginalContent {...props} />
     </>
   );
 }

--- a/src/theme/DocSidebar/Mobile/index.js
+++ b/src/theme/DocSidebar/Mobile/index.js
@@ -1,34 +1,25 @@
 import React, { useEffect } from 'react';
 import { NavbarSecondaryMenuFiller } from '@docusaurus/theme-common';
-import { useDocsSidebar } from '@docusaurus/plugin-content-docs/client';
 import { useMobileNav } from '../../../components/MobileNavContext';
 
-// Populates MobileNavContext so the overlay in Navbar/Layout can render sidebar
-// items for either section without needing to navigate first.
-function DocSidebarMobileSecondaryMenu({ sidebar, path, sidebarName }) {
-  const { setSidebarForType } = useMobileNav();
+// Populates MobileNavContext with the CURRENT page's real sidebar, so the
+// audience overlay in Navbar/Layout (rendered outside the doc page's
+// DocsSidebarProvider tree) can display it.
+function DocSidebarMobileSecondaryMenu({ sidebar, path }) {
+  const { setSidebar } = useMobileNav();
 
   useEffect(() => {
-    // Use the sidebar's explicit name (from DocsSidebarProvider in DocPage context)
-    // as the ground truth for which section this sidebar belongs to.
-    // This avoids all URL-path parsing and race conditions.
-    const type = sidebarName === 'technical_users' ? 'technical' : 'business';
-    setSidebarForType(type, { items: sidebar, path });
-  }, [sidebar, path, sidebarName, setSidebarForType]);
+    setSidebar({ items: sidebar, path });
+  }, [sidebar, path, setSidebar]);
 
   return null;
 }
 
 function DocSidebarMobile(props) {
-  // useDocsSidebar() works here because DocSidebarMobile is rendered inside
-  // DocPage which wraps children with DocsSidebarProvider.
-  const docsSidebar = useDocsSidebar();
-  const extendedProps = { ...props, sidebarName: docsSidebar?.name ?? '' };
-
   return (
     <NavbarSecondaryMenuFiller
       component={DocSidebarMobileSecondaryMenu}
-      props={extendedProps}
+      props={props}
     />
   );
 }

--- a/src/theme/Navbar/Layout/index.js
+++ b/src/theme/Navbar/Layout/index.js
@@ -181,9 +181,8 @@ function OverlayColumns({ items, activePath, onClose }) {
 
 // Custom navigation overlay — renders below the secondary audience bar,
 // slides top-to-bottom, shows the current doc sidebar via MobileNavContext.
-function MobileNavOverlay({ isOpen, onClose, activeSection }) {
-  const { sidebars } = useMobileNav();
-  const sidebar = sidebars[activeSection] ?? null;
+function MobileNavOverlay({ isOpen, onClose }) {
+  const { sidebar } = useMobileNav();
   const location = useLocation();
   const scrollerRef = useRef(null);
 
@@ -343,47 +342,30 @@ function VersionBlock() {
 }
 
 
-function AudienceBlocks({ overlayOpen, activeSection, onSelect }) {
+function AudienceBlocks({ overlayOpen, onToggleOwnSection, onNavigateAway }) {
   const { userType, setUserType } = useUserType();
-  const { sidebars } = useMobileNav();
   const history = useHistory();
-  // Tracks a pending seed navigation that should run AFTER the overlay renders.
-  const [pendingSeedPath, setPendingSeedPath] = useState(null);
-
-  // Run the deferred seed navigation after the overlay has been painted.
-  // useEffect fires after the browser has committed the render, so the user
-  // sees the overlay open before the page URL changes behind it.
-  useEffect(() => {
-    if (!pendingSeedPath) return;
-    history.push(pendingSeedPath);
-    setPendingSeedPath(null);
-  }, [pendingSeedPath, history]);
 
   function handleClick(e, tab) {
     e.preventDefault();
 
-    if (tab.key === activeSection && overlayOpen) {
-      onSelect(tab.key, false, null);
+    if (tab.key === userType) {
+      // Tapping your own current section toggles the overlay to browse it.
+      onToggleOwnSection(e.currentTarget);
       return;
     }
 
-    onSelect(tab.key, true, e.currentTarget);
-
-    // First tap on a section whose sidebar hasn't been cached yet: navigate to
-    // seed MobileNavContext. setUserType runs NOW (not deferred) so the
-    // UserTypeContext redirect guard doesn't fire when we land on '/'.
-    if (!sidebars[tab.key]) {
-      setUserType(tab.key);
-      setPendingSeedPath(tab.path); // navigation deferred to after overlay renders
-    }
+    // Switching to the other section always navigates for real — no cached
+    // preview, so the destination sidebar is always guaranteed fresh.
+    onNavigateAway();
+    setUserType(tab.key);
+    history.push(tab.path);
   }
 
   return (
     <>
       {TABS.map((tab) => {
-        // While overlay is open, highlight the section being browsed.
-        // While closed, highlight the section matching the current page.
-        const isActive = overlayOpen ? tab.key === activeSection : tab.key === userType;
+        const isActive = tab.key === userType;
         return (
           <a
             key={tab.key}
@@ -413,15 +395,8 @@ function AudienceBlocks({ overlayOpen, activeSection, onSelect }) {
 }
 
 export default function NavbarLayoutWrapper(props) {
-  const { userType } = useUserType();
   const [overlayOpen, setOverlayOpen] = useState(false);
-  const [activeSection, setActiveSection] = useState(userType);
   const triggerRef = useRef(null);
-
-  // Keep activeSection in sync with the current page when overlay is closed.
-  useEffect(() => {
-    if (!overlayOpen) setActiveSection(userType);
-  }, [userType, overlayOpen]);
 
   // Auto-close when the viewport crosses above the mobile breakpoint (e.g.
   // rotating to landscape on a tablet, or resizing a desktop window). The
@@ -522,10 +497,13 @@ export default function NavbarLayoutWrapper(props) {
     };
   }, [overlayOpen]);
 
-  function handleSelect(key, open, triggerEl) {
-    if (open && triggerEl) triggerRef.current = triggerEl;
-    setActiveSection(key);
-    setOverlayOpen(open);
+  function handleToggleOwnSection(triggerEl) {
+    triggerRef.current = triggerEl;
+    setOverlayOpen((open) => !open);
+  }
+
+  function handleNavigateAway() {
+    setOverlayOpen(false);
   }
 
   const closeOverlay = () => setOverlayOpen(false);
@@ -534,12 +512,16 @@ export default function NavbarLayoutWrapper(props) {
     <>
       <NavbarLayout {...props} />
       <nav className={styles.audienceBar} aria-label="Documentation section">
-        <AudienceBlocks overlayOpen={overlayOpen} activeSection={activeSection} onSelect={handleSelect} />
+        <AudienceBlocks
+          overlayOpen={overlayOpen}
+          onToggleOwnSection={handleToggleOwnSection}
+          onNavigateAway={handleNavigateAway}
+        />
         <ErrorCauseBoundary onError={() => null}>
           <VersionBlock />
         </ErrorCauseBoundary>
       </nav>
-      <MobileNavOverlay isOpen={overlayOpen} onClose={closeOverlay} activeSection={activeSection} />
+      <MobileNavOverlay isOpen={overlayOpen} onClose={closeOverlay} />
     </>
   );
 }

--- a/versioned_docs/version-v6.0.0/support/release-notes.mdx
+++ b/versioned_docs/version-v6.0.0/support/release-notes.mdx
@@ -1,7 +1,6 @@
 ---
 sidebar_label: Release notes
 title: Release notes
-slug: release-notes
 hide_table_of_contents: true
 pagination_prev: null
 pagination_next: null

--- a/versioned_docs/version-v6.0.0/support/release-notes.mdx
+++ b/versioned_docs/version-v6.0.0/support/release-notes.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_label: Release notes
 title: Release notes
+slug: release-notes
 hide_table_of_contents: true
 pagination_prev: null
 pagination_next: null


### PR DESCRIPTION
The new sidebar with mobile support was incorrectly using caches that stores the user's choice. This PR fixes that by removing the snapshots entirely. Slower to toggle the navigation, but more correct.